### PR TITLE
acrn-hypervisor: add tag regex for upstream release checking

### DIFF
--- a/recipes-core/acrn/acrn-common.inc
+++ b/recipes-core/acrn/acrn-common.inc
@@ -11,6 +11,8 @@ SRC_URI = "git://github.com/projectacrn/acrn-hypervisor.git;branch=release_1.0 \
 PV = "1.0"
 SRCREV = "3f2dde4ee5a4b36ec0ce30e7ae81e41416aa7364"
 
+UPSTREAM_CHECK_GITTAGREGEX = "^v(?P<pver>\d+(\.\d+)+)$"
+
 S = "${WORKDIR}/git/"
 
 # 1 for release build, 0 for debug build.


### PR DESCRIPTION
Ensure we only find tags like 'v1.0', otherwise the snapshot tags in the form of
'acrn-2019w19.4-140000p' are parsed as version 2019.

Signed-off-by: Ross Burton <ross.burton@intel.com>