### PR TITLE
acrn-image-weston: add recipe

### DIFF
--- a/recipes-core/images/acrn-image-weston.bb
+++ b/recipes-core/images/acrn-image-weston.bb
@@ -1,0 +1,9 @@
+require recipes-graphics/images/core-image-weston.bb
+
+CORE_IMAGE_EXTRA_INSTALL_append = " \
+    packagegroup-acrn \
+    linux-firmware \
+    kernel-modules \
+"
+
+inherit image-acrn


### PR DESCRIPTION
This enables building SOS and UOS with weston for a more accurate
comparison, as acrn-image-sato SOS produces extremely low glmark2 score.
On acrn-image-sato, glmark2-es2 score is 4x lower than
glmark2-es-wayland and thus rendering relative comparison impossible.

Signed-off-by: Chin Huat Ang <chin.huat.ang@intel.com>