### PR TITLE
Add initial Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: python
+python:
+- "3.6"
+
+addons:
+  apt:
+    packages:
+    - chrpath
+    - diffstat
+    - texinfo
+
+env:
+  global:
+  - MACHINE=qemux86-64
+  - DISTRO=acrn-demo-sos
+
+install:
+ - git clone --depth=50 --branch=master git://git.yoctoproject.org/poky ../poky
+ - . ../poky/oe-init-build-env $TRAVIS_BUILD_DIR/build
+ - bitbake-layers add-layer ../../meta-acrn
+
+script:
+ - bitbake packagegroup-acrn --parse-only
+ - bitbake packagegroup-acrn --dry-run
+ - devtool latest-version acrn-hypervisor


### PR DESCRIPTION
This is a pretty simple Travis setup that just clones Poky and verifies that the
layer parses.

Lots of future improvements, such as:
* Verify the parse against master and warrior
* Use public sstate cache and actually build
* Somehow expose the latest version check