### PR TITLE
acrn: upgrade to acrn 1.4

### DIFF
--- a/recipes-core/acrn/acrn-common.inc
+++ b/recipes-core/acrn/acrn-common.inc
@@ -3,13 +3,13 @@ HOMEPAGE = "https://projectacrn.org/"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=5732af37bf18525ed9d2b16985054901"
 
-SRC_URI = "git://github.com/projectacrn/acrn-hypervisor.git;branch=release_1.3 \
+SRC_URI = "git://github.com/projectacrn/acrn-hypervisor.git;branch=release_1.4 \
            file://paths.patch"
 
 # Snapshot tags are of the format:
 # acrn-<year>w<week>.<day>-<timestamp><pass|fail>
-PV = "1.3"
-SRCREV = "c4f5de24494e64e01cb75cc165841f36a974baad"
+PV = "1.4"
+SRCREV = "bce4b61db75de493a80cbee860f655c6fc5d92e2"
 
 UPSTREAM_CHECK_GITTAGREGEX = "^v(?P<pver>\d+(\.\d+)+)$"
 

--- a/recipes-core/acrn/acrn-tools/no-crashlog.patch
+++ b/recipes-core/acrn/acrn-tools/no-crashlog.patch
@@ -1,32 +1,32 @@
+From b0a7ba35f9598f0f27f569d889fceef51b68002f Mon Sep 17 00:00:00 2001
+From: Ross Burton <ross.burton@intel.com>
+Date: Fri, 15 Mar 2019 12:20:16 +0000
+Subject: [PATCH] disable crashlog
+
 Temporarily disable acrn-crashlog until we can integrate it properly.
 
 Upstream-Status: Inappropriate
 Signed-off-by: Ross Burton <ross.burton@intel.com>
 
-From edea6fe6dee98f67fd4669eed2e1d730e61adb55 Mon Sep 17 00:00:00 2001
-From: Ross Burton <ross.burton@intel.com>
-Date: Fri, 15 Mar 2019 12:20:16 +0000
-Subject: [PATCH 1/2] disable crashlog
-
 ---
- tools/Makefile | 4 ++--
+ misc/Makefile | 4 ++--
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/misc/Makefile b/misc/Makefile
-index de7ecdae..56475368 100644
+index 2663eab..850d862 100644
 --- a/misc/Makefile
 +++ b/misc/Makefile
 @@ -4,7 +4,7 @@ RELEASE ?= 0
-
- .PHONY: all acrn-crashlog acrnlog acrn-manager acrntrace acrnbridge
+ 
+ .PHONY: all acrn-crashlog acrnlog acrn-manager acrntrace acrnbridge life_mngr
  ifeq ($(RELEASE),0)
 -all: acrn-crashlog acrnlog acrn-manager acrntrace acrnbridge
 +all: acrnlog acrn-manager acrntrace acrnbridge
  else
  all: acrn-manager acrnbridge
  endif
-@@ -34,7 +34,7 @@ clean:
-
+@@ -38,7 +38,7 @@ clean:
+ 
  .PHONY: install
  ifeq ($(RELEASE),0)
 -install: acrn-crashlog-install acrnlog-install acrn-manager-install acrntrace-install acrnbridge-install
@@ -34,5 +34,3 @@ index de7ecdae..56475368 100644
  else
  install: acrn-manager-install acrnbridge-install
  endif
---
-2.11.0

--- a/recipes-core/acrn/files/paths.patch
+++ b/recipes-core/acrn/files/paths.patch
@@ -1,4 +1,4 @@
-From b3b09a17eea9d171b03e82a4d5430113b9012388 Mon Sep 17 00:00:00 2001
+From 63a9da3bb8369abe50572ff1abd812f4fb3d9300 Mon Sep 17 00:00:00 2001
 From: Ross Burton <ross.burton@intel.com>
 Date: Tue, 15 Jan 2019 14:49:48 +0000
 Subject: [PATCH] XXX tools: don't hardcode install paths
@@ -72,7 +72,7 @@ index f293414..1256a96 100644
 +	install -d $(DESTDIR)$(datadir)/acrn/bios
 +	install -D --mode=0664 -t $(DESTDIR)$(datadir)/acrn/bios $^
 diff --git a/hypervisor/Makefile b/hypervisor/Makefile
-index ac743a1..d93cf71 100644
+index 3940930..1b30d25 100644
 --- a/hypervisor/Makefile
 +++ b/hypervisor/Makefile
 @@ -68,6 +68,8 @@ else ifeq ($(CONFIG_HYBRID),y)
@@ -84,7 +84,7 @@ index ac743a1..d93cf71 100644
  LD_IN_TOOL = scripts/genld.sh
  BASH = $(shell which bash)
  
-@@ -366,11 +368,11 @@ endif
+@@ -371,11 +373,11 @@ endif
  all: cfg_src pre_build $(HV_OBJDIR)/$(HV_FILE).32.out $(HV_OBJDIR)/$(HV_FILE).bin
  
  install: $(HV_OBJDIR)/$(HV_FILE).32.out

--- a/recipes-guests/yocto/core-image-base-package/launch-base.sh
+++ b/recipes-guests/yocto/core-image-base-package/launch-base.sh
@@ -24,7 +24,7 @@ fi
 #for memsize setting
 mem_size=2048M
 
-acrn-dm -A -m $mem_size -c $2 -s 0:0,hostbridge -s 1:0,lpc -l com1,stdio \
+acrn-dm -A -m $mem_size -s 0:0,hostbridge -s 1:0,lpc -l com1,stdio \
   -s 5,virtio-console,@pty:pty_port \
   -s 6,virtio-hyper_dmabuf \
   -s 3,virtio-blk,/var/lib/machines/core-image-base.ext4 \

--- a/recipes-guests/yocto/core-image-sato-package/launch-sato.sh
+++ b/recipes-guests/yocto/core-image-sato-package/launch-sato.sh
@@ -24,7 +24,7 @@ fi
 #for memsize setting
 mem_size=2048M
 
-acrn-dm -A -m $mem_size -c $2 -s 0:0,hostbridge -s 1:0,lpc -l com1,stdio \
+acrn-dm -A -m $mem_size  -s 0:0,hostbridge -s 1:0,lpc -l com1,stdio \
   -s 2,pci-gvt -G "$3" \
   -s 5,virtio-console,@pty:pty_port \
   -s 6,virtio-hyper_dmabuf \

--- a/recipes-guests/yocto/core-image-weston-package/launch-weston.sh
+++ b/recipes-guests/yocto/core-image-weston-package/launch-weston.sh
@@ -24,7 +24,7 @@ fi
 #for memsize setting
 mem_size=2048M
 
-acrn-dm -A -m $mem_size -c $2 -s 0:0,hostbridge -s 1:0,lpc -l com1,stdio \
+acrn-dm -A -m $mem_size -s 0:0,hostbridge -s 1:0,lpc -l com1,stdio \
   -s 2,pci-gvt -G "$3" \
   -s 5,virtio-console,@pty:pty_port \
   -s 6,virtio-hyper_dmabuf \


### PR DESCRIPTION
upgrade to acrn 1.4

update launch UOS script to remove acrn-dm "-c" option which
no longer applies for acrn 1.4.

Signed-off-by: Chee Yang Lee <chee.yang.lee@intel.com>