### PR TITLE
Ovmf support

### DIFF
--- a/classes/container-package.bbclass
+++ b/classes/container-package.bbclass
@@ -21,6 +21,5 @@ do_install[mcdepends] += "multiconfig::${CONTAINER_PACKAGE_MC}:${IMAGE_NAME}:do_
 
 do_install () {
 	install -d ${D}${containerdir}
-	install ${CONTAINER_PACKAGE_DEPLOY_DIR}/${IMAGE_NAME}-${MACHINE}.ext4 ${D}${containerdir}/${IMAGE_NAME}.ext4
-	install ${CONTAINER_PACKAGE_DEPLOY_DIR}/${KERNEL_IMAGETYPE} ${D}${containerdir}/${IMAGE_NAME}.${KERNEL_IMAGETYPE}
+	install ${CONTAINER_PACKAGE_DEPLOY_DIR}/${IMAGE_NAME}-${MACHINE}.wic ${D}${containerdir}/${IMAGE_NAME}.wic
 }

--- a/conf/distro/acrn-demo-uos.conf
+++ b/conf/distro/acrn-demo-uos.conf
@@ -6,8 +6,11 @@ DISTRO_NAME += "(UOS)"
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-intel-acrn-uos"
 
 # UOS images are always ext4
-IMAGE_FSTYPES = "ext4"
+IMAGE_FSTYPES = "wic ext4"
 
 # Ensure images typically include networkd-config so that networking is
 # configured.
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += "networkd-config"
+
+APPEND += " rw maxcpus=1 nohpet console=hvc0 console=ttyS0 no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable \
+            i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x070F00"

--- a/recipes-guests/yocto/core-image-base-package/launch-base.sh
+++ b/recipes-guests/yocto/core-image-base-package/launch-base.sh
@@ -27,13 +27,11 @@ mem_size=2048M
 acrn-dm -A -m $mem_size -s 0:0,hostbridge -s 1:0,lpc -l com1,stdio \
   -s 5,virtio-console,@pty:pty_port \
   -s 6,virtio-hyper_dmabuf \
-  -s 3,virtio-blk,/var/lib/machines/core-image-base.ext4 \
+  -s 3,virtio-blk,/var/lib/machines/core-image-base.wic \
   -s 4,virtio-net,tap0 \
+  --ovmf /usr/share/acrn/bios/OVMF.fd \
   --mac_seed $mac_seed \
-  -k /var/lib/machines/core-image-base.bzImage \
-  -B "root=/dev/vda rw rootwait maxcpus=$2 nohpet console=tty0 console=hvc0 \
-  console=ttyS0 no_timer_check ignore_loglevel log_buf_len=16M \
-  consoleblank=0 tsc=reliable" $vm_name
+  $vm_name
 }
 
 # offline SOS CPUs except BSP before launch UOS

--- a/recipes-guests/yocto/core-image-sato-package/launch-sato.sh
+++ b/recipes-guests/yocto/core-image-sato-package/launch-sato.sh
@@ -28,14 +28,10 @@ acrn-dm -A -m $mem_size  -s 0:0,hostbridge -s 1:0,lpc -l com1,stdio \
   -s 2,pci-gvt -G "$3" \
   -s 5,virtio-console,@pty:pty_port \
   -s 6,virtio-hyper_dmabuf \
-  -s 3,virtio-blk,/var/lib/machines/core-image-sato.ext4 \
+  -s 3,virtio-blk,/var/lib/machines/core-image-sato.wic \
   -s 4,virtio-net,tap0 \
+  --ovmf /usr/share/acrn/bios/OVMF.fd \
   --mac_seed $mac_seed \
-  -k /var/lib/machines/core-image-sato.bzImage \
-  -B "root=/dev/vda rw rootwait maxcpus=$2 nohpet console=tty0 console=hvc0 \
-  console=ttyS0 no_timer_check ignore_loglevel log_buf_len=16M \
-  consoleblank=0 tsc=reliable \
-  i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=$4" \
   $vm_name
 }
 

--- a/recipes-guests/yocto/core-image-weston-package/launch-weston.sh
+++ b/recipes-guests/yocto/core-image-weston-package/launch-weston.sh
@@ -28,14 +28,10 @@ acrn-dm -A -m $mem_size -s 0:0,hostbridge -s 1:0,lpc -l com1,stdio \
   -s 2,pci-gvt -G "$3" \
   -s 5,virtio-console,@pty:pty_port \
   -s 6,virtio-hyper_dmabuf \
-  -s 3,virtio-blk,/var/lib/machines/core-image-weston.ext4 \
+  -s 3,virtio-blk,/var/lib/machines/core-image-weston.wic \
   -s 4,virtio-net,tap0 \
+  --ovmf /usr/share/acrn/bios/OVMF.fd \
   --mac_seed $mac_seed \
-  -k /var/lib/machines/core-image-weston.bzImage \
-  -B "root=/dev/vda rw rootwait maxcpus=$2 nohpet console=tty0 console=hvc0 \
-  console=ttyS0 no_timer_check ignore_loglevel log_buf_len=16M \
-  consoleblank=0 tsc=reliable \
-  i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=$4" \
   $vm_name
 }
 


### PR DESCRIPTION
Update the launch scripts to launch User VM to directly use
the 'OVMF.fd' bios file installed by default 
in '/usr/share/acrn/bios/'