### PR TITLE
acrn-kernel: add recipes for SOS & UOS

### DIFF
--- a/recipes-kernel/linux/acrn-kernel-sos_4.19.bb
+++ b/recipes-kernel/linux/acrn-kernel-sos_4.19.bb
@@ -1,0 +1,7 @@
+require acrn-kernel.inc
+
+SRC_URI_append = "  file://sos.cfg"
+
+LINUX_VERSION_EXTENSION ?= "-acrn-kernel-sos"
+
+SUMMARY = "ACRN Kernel (SOS)"

--- a/recipes-kernel/linux/acrn-kernel-uos_4.19.bb
+++ b/recipes-kernel/linux/acrn-kernel-uos_4.19.bb
@@ -1,0 +1,7 @@
+require acrn-kernel.inc
+
+SRC_URI_append = "  file://uos.cfg"
+
+LINUX_VERSION_EXTENSION ?= "-acrn-kernel-uos"
+
+SUMMARY = "ACRN Kernel (UOS)"

--- a/recipes-kernel/linux/acrn-kernel.inc
+++ b/recipes-kernel/linux/acrn-kernel.inc
@@ -1,0 +1,12 @@
+require recipes-kernel/linux/linux-intel_4.19.bb
+
+KBRANCH = "master"
+
+SRC_URI_remove = "git://github.com/intel/linux-intel-lts.git;protocol=https;name=machine;branch=${KBRANCH};"
+SRC_URI_prepend = "git://github.com/projectacrn/acrn-kernel.git;protocol=https;name=machine;branch=${KBRANCH};"
+
+# tag: v1.5.1
+LINUX_VERSION = "4.19.73"
+SRCREV_machine = "0bf3d99ba46b80a87f7b0f2864ba0432e34a9070"
+
+KERNEL_EXTRA_FEATURES += " cfg/hv-guest.scc  cfg/paravirt_kvm.scc "


### PR DESCRIPTION
Builds v4.19.73 (tag: v1.5.1) from projectacrn/acrn-kernel

Kernel configuration: In addition to intel-common kernel configs
from yocto-kernel-cache, sos.conf for SOS and uos.conf for UOS
is applied.

For SOS: in local.conf
PREFERRED_PROVIDER_virtual/kernel = "acrn-kernel-sos"

For UOS: in uos.conf
PREFERRED_PROVIDER_virtual/kernel = "acrn-kernel-uos"

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>