### PR TITLE
acrn-common: fix build with ACRN_RELEASE=1

### DIFF
--- a/recipes-core/acrn/acrn-common.inc
+++ b/recipes-core/acrn/acrn-common.inc
@@ -4,7 +4,8 @@ LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=5732af37bf18525ed9d2b16985054901"
 
 SRC_URI = "git://github.com/projectacrn/acrn-hypervisor.git;branch=release_1.5 \
-           file://paths.patch"
+           file://paths.patch \
+           file://0001-hypervisor-Makefile-do-not-strip.patch"
 
 # Snapshot tags are of the format:
 # acrn-<year>w<week>.<day>-<timestamp><pass|fail>

--- a/recipes-core/acrn/files/0001-hypervisor-Makefile-do-not-strip.patch
+++ b/recipes-core/acrn/files/0001-hypervisor-Makefile-do-not-strip.patch
@@ -1,0 +1,54 @@
+From e5fbcc89856d0f3662848265a9f170b9ef40bb45 Mon Sep 17 00:00:00 2001
+From: Naveen Saini <naveen.kumar.saini@intel.com>
+Date: Tue, 4 Feb 2020 14:49:52 +0800
+Subject: [PATCH] hypervisor/Makefile: do not strip
+
+It caused QA Issue:
+--------------
+|ERROR: QA Issue: File '/usr/lib/acrn/acrn.nuc7i7dnb.sdc.efi.out' from
+acrn-hypervisor was already stripped, this will prevent future
+debugging! [already-stripped]
+
+|ERROR: QA Issue: File '/usr/bin/acrn-dm' from acrn-devicemodel
+was already stripped, this will prevent future debugging! [already-stripped]
+--------------
+
+Upstream-Status: Inappropriate [oe specific]
+
+Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>
+---
+ devicemodel/Makefile | 2 --
+ hypervisor/Makefile  | 4 ----
+ 2 files changed, 6 deletions(-)
+
+diff --git a/devicemodel/Makefile b/devicemodel/Makefile
+index 7213642a..418a6342 100644
+--- a/devicemodel/Makefile
++++ b/devicemodel/Makefile
+@@ -52,8 +52,6 @@ endif
+ 
+ ifeq ($(RELEASE),0)
+ CFLAGS += -DDM_DEBUG
+-else
+-LDFLAGS += -s
+ endif
+ 
+ 
+diff --git a/hypervisor/Makefile b/hypervisor/Makefile
+index e8694eef..344e5ed5 100644
+--- a/hypervisor/Makefile
++++ b/hypervisor/Makefile
+@@ -113,10 +113,6 @@ else
+ LDFLAGS += -static
+ endif
+ 
+-ifeq (y, $(CONFIG_RELEASE))
+-LDFLAGS += -s
+-endif
+-
+ ARCH_CFLAGS += -gdwarf-2
+ ARCH_ASFLAGS += -gdwarf-2 -DASSEMBLER=1
+ ARCH_ARFLAGS +=
+-- 
+2.17.1
+


### PR DESCRIPTION
acrn.efi and acrn-dm binaries are being stripped by source Makefile
in release mode, which cause below build failures:

|ERROR: QA Issue: File '/usr/lib/acrn/acrn.nuc7i7dnb.sdc.efi.out' from
acrn-hypervisor was already stripped, this will prevent future
debugging! [already-stripped]

|ERROR: QA Issue: File '/usr/bin/acrn-dm' from acrn-devicemodel
was already stripped, this will prevent future debugging! [already-stripped]

Let yocto do the stripping.

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>