### PR TITLE
acrn-hypervisor: dont use build/hypervisor/.config

### DIFF
--- a/recipes-core/acrn/acrn-common.inc
+++ b/recipes-core/acrn/acrn-common.inc
@@ -5,7 +5,8 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=5732af37bf18525ed9d2b16985054901"
 
 SRC_URI = "git://github.com/projectacrn/acrn-hypervisor.git;branch=release_1.5 \
            file://paths.patch \
-           file://0001-hypervisor-Makefile-do-not-strip.patch"
+           file://0001-hypervisor-Makefile-do-not-strip.patch \
+           file://0001-acrn-config-append-kconfig-setting-on-new-board.patch"
 
 # Snapshot tags are of the format:
 # acrn-<year>w<week>.<day>-<timestamp><pass|fail>

--- a/recipes-core/acrn/acrn-hypervisor.bb
+++ b/recipes-core/acrn/acrn-hypervisor.bb
@@ -16,14 +16,11 @@ DEPENDS += "python3-kconfiglib-native"
 DEPENDS += "${@'gnu-efi' if d.getVar('ACRN_FIRMWARE') == 'uefi' else ''}"
 
 do_configure() {
-	mkdir --parents ${B}/hypervisor
-	cat <<-EOF >> ${B}/hypervisor/.config
-CONFIG_BOARD="${ACRN_BOARD}"
+	cat <<-EOF >> ${S}/hypervisor/arch/x86/configs/${ACRN_BOARD}.config
 CONFIG_$(echo ${ACRN_SCENARIO} | tr '[:lower:]' '[:upper:]')=y
 CONFIG_UEFI_OS_LOADER_NAME="\\\\EFI\\\\BOOT\\\\bootx64.efi"
 EOF
-	cat ${B}/hypervisor/.config
-	oe_runmake -C hypervisor oldconfig
+	cat ${S}/hypervisor/arch/x86/configs/${ACRN_BOARD}.config
 }
 
 

--- a/recipes-core/acrn/files/0001-acrn-config-append-kconfig-setting-on-new-board.patch
+++ b/recipes-core/acrn/files/0001-acrn-config-append-kconfig-setting-on-new-board.patch
@@ -1,0 +1,31 @@
+From 0eccde3eb907a74c46a58ff827bbfc2bb90dadce Mon Sep 17 00:00:00 2001
+From: Victor Sun <victor.sun@intel.com>
+Date: Wed, 5 Feb 2020 16:43:00 +0800
+Subject: [PATCH] acrn-config: append kconfig setting on new board
+
+When user has already prepared some default kconfig settings in
+hypervisor/arch/x86/configs/$(BOARD).config file even the board is new
+to Acrn source, the acrn-config will keep these settings and append other
+suggested settings on the end of the $(BOARD).config file.
+
+Signed-off-by: Victor Sun <victor.sun@intel.com>
+---
+ misc/acrn-config/board_config/board_cfg_gen.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/misc/acrn-config/board_config/board_cfg_gen.py b/misc/acrn-config/board_config/board_cfg_gen.py
+index defd1bf..ffbef40 100755
+--- a/misc/acrn-config/board_config/board_cfg_gen.py
++++ b/misc/acrn-config/board_config/board_cfg_gen.py
+@@ -114,7 +114,7 @@ def main(args):
+ 
+     # generate new board_name.config
+     if need_gen_new_board_config(board):
+-        with open(config_board_kconfig, 'w+') as config:
++        with open(config_board_kconfig, 'a+') as config:
+             err_dic = new_board_kconfig.generate_file(config)
+             if err_dic:
+                 return err_dic
+-- 
+2.7.4
+


### PR DESCRIPTION

dont use build/hypervisor/.config, instead use
hypervisor/arch/x86/configs/${ACRN_BOARD}.config to
prevent override.
retire oe_runmake from do_configure as no longer required.

Signed-off-by: Chee Yang Lee <chee.yang.lee@intel.com>