### PR TITLE
acrn-efi-setup: dont disable uart

### DIFF
--- a/recipes-core/acrn/acrn-efi-setup/acrn-efi-setup.sh
+++ b/recipes-core/acrn/acrn-efi-setup/acrn-efi-setup.sh
@@ -13,4 +13,4 @@ done
 
 efibootmgr -c -l "\EFI\BOOT\acrn.efi" \
     -L "ACRN (Yocto)" \
-    -u "bootloader=\EFI\BOOT\bootx64.efi uart=disabled"
+    -u "bootloader=\EFI\BOOT\bootx64.efi"


### PR DESCRIPTION
dont disable uart in efi setup script.
let ACRN_RELEASE do the job.

Signed-off-by: Chee Yang Lee <chee.yang.lee@intel.com>