### PR TITLE
acrn-kernel: switch to branch release_1.5

### DIFF
--- a/recipes-kernel/linux/acrn-kernel.inc
+++ b/recipes-kernel/linux/acrn-kernel.inc
@@ -1,12 +1,12 @@
 require recipes-kernel/linux/linux-intel_4.19.bb
 
-KBRANCH = "master"
+KBRANCH = "release_1.5"
 
 SRC_URI_remove = "git://github.com/intel/linux-intel-lts.git;protocol=https;name=machine;branch=${KBRANCH};"
 SRC_URI_prepend = "git://github.com/projectacrn/acrn-kernel.git;protocol=https;name=machine;branch=${KBRANCH};"
 
 # tag: v1.5.1
 LINUX_VERSION = "4.19.73"
-SRCREV_machine = "0bf3d99ba46b80a87f7b0f2864ba0432e34a9070"
+SRCREV_machine = "973ca1cc0184fc77daa553d4bf9edce8d84bc830"
 
 KERNEL_EXTRA_FEATURES += " cfg/hv-guest.scc  cfg/paravirt_kvm.scc "


### PR DESCRIPTION
recent rebase in projectacrn/acrn-kernel has removed commit ID
0bf3d99ba46b80a87f7b0f2864ba0432e34a9070 from master branch.
switch to release branch instead of master.

Signed-off-by: Chee Yang Lee <chee.yang.lee@intel.com>