### PR TITLE
layer.conf: update LAYERSERIES_COMPAT to dunfell

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -8,4 +8,4 @@ BBFILE_PATTERN_meta-acrn = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-acrn = "5"
 
 LAYERDEPENDS_meta-acrn = "core intel"
-LAYERSERIES_COMPAT_meta-acrn = "warrior zeus"
+LAYERSERIES_COMPAT_meta-acrn = "dunfell"


### PR DESCRIPTION
ACRN Hypervisor have dependencies on acpica version, so
it will work only with dunfell so remove all other branches

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>