### PR TITLE
linux: drop dependency on meta-intel linux-intel 4.19

### DIFF
--- a/recipes-kernel/linux/acrn-kernel.inc
+++ b/recipes-kernel/linux/acrn-kernel.inc
@@ -1,9 +1,12 @@
-require recipes-kernel/linux/linux-intel_4.19.bb
+require linux-intel-acrn.inc
 
 KBRANCH = "release_1.6"
 
 SRC_URI_remove = "git://github.com/intel/linux-intel-lts.git;protocol=https;name=machine;branch=${KBRANCH};"
 SRC_URI_prepend = "git://github.com/projectacrn/acrn-kernel.git;protocol=https;name=machine;branch=${KBRANCH};"
+
+SRC_URI_remove = "file://0001-Add-the-plane-restrictionfor-SKL.-Otherwise-there-is.patch"
+SRC_URI_remove = "file://0002-Add-the-change-for-gvt-g-on-SKL.patch"
 
 # tag: v1.6
 LINUX_VERSION = "4.19.106"

--- a/recipes-kernel/linux/files/perf-fix-build-with-binutils.patch
+++ b/recipes-kernel/linux/files/perf-fix-build-with-binutils.patch
@@ -1,0 +1,60 @@
+From 0ada120c883d4f1f6aafd01cf0fbb10d8bbba015 Mon Sep 17 00:00:00 2001
+From: Changbin Du <changbin.du@gmail.com>
+Date: Tue, 28 Jan 2020 23:29:38 +0800
+Subject: [PATCH] perf: Make perf able to build with latest libbfd
+
+libbfd has changed the bfd_section_* macros to inline functions
+bfd_section_<field> since 2019-09-18. See below two commits:
+  o http://www.sourceware.org/ml/gdb-cvs/2019-09/msg00064.html
+  o https://www.sourceware.org/ml/gdb-cvs/2019-09/msg00072.html
+
+This fix make perf able to build with both old and new libbfd.
+
+Signed-off-by: Changbin Du <changbin.du@gmail.com>
+Acked-by: Jiri Olsa <jolsa@redhat.com>
+Cc: Peter Zijlstra <peterz@infradead.org>
+Link: http://lore.kernel.org/lkml/20200128152938.31413-1-changbin.du@gmail.com
+Signed-off-by: Arnaldo Carvalho de Melo <acme@redhat.com>
+
+Upstream-Status: Backport [https://github.com/torvalds/linux/commit/0ada120c883d4f1f6aafd01cf0fbb10d8bbba015]
+Signed-off-by: Anuj Mittal <anuj.mittal@intel.com>
+---
+ tools/perf/util/srcline.c | 16 +++++++++++++++-
+ 1 file changed, 15 insertions(+), 1 deletion(-)
+
+diff --git a/tools/perf/util/srcline.c b/tools/perf/util/srcline.c
+index 6ccf6f6d09df9..5b7d6c16d33fe 100644
+--- a/tools/perf/util/srcline.c
++++ b/tools/perf/util/srcline.c
+@@ -193,16 +193,30 @@ static void find_address_in_section(bfd *abfd, asection *section, void *data)
+ 	bfd_vma pc, vma;
+ 	bfd_size_type size;
+ 	struct a2l_data *a2l = data;
++	flagword flags;
+ 
+ 	if (a2l->found)
+ 		return;
+ 
+-	if ((bfd_get_section_flags(abfd, section) & SEC_ALLOC) == 0)
++#ifdef bfd_get_section_flags
++	flags = bfd_get_section_flags(abfd, section);
++#else
++	flags = bfd_section_flags(section);
++#endif
++	if ((flags & SEC_ALLOC) == 0)
+ 		return;
+ 
+ 	pc = a2l->addr;
++#ifdef bfd_get_section_vma
+ 	vma = bfd_get_section_vma(abfd, section);
++#else
++	vma = bfd_section_vma(section);
++#endif
++#ifdef bfd_get_section_size
+ 	size = bfd_get_section_size(section);
++#else
++	size = bfd_section_size(section);
++#endif
+ 
+ 	if (pc < vma || pc >= vma + size)
+ 		return;

--- a/recipes-kernel/linux/linux-intel-acrn-sos_4.19.bb
+++ b/recipes-kernel/linux/linux-intel-acrn-sos_4.19.bb
@@ -1,9 +1,7 @@
 require linux-intel-acrn.inc
-require recipes-kernel/linux/linux-intel_4.19.bb
 
 SRC_URI_append = "  file://sos.cfg"
 
 LINUX_VERSION_EXTENSION ?= "-linux-intel-acrn-sos"
 
 SUMMARY = "Linux Kernel with ACRN enabled (SOS)"
-

--- a/recipes-kernel/linux/linux-intel-acrn-uos_4.19.bb
+++ b/recipes-kernel/linux/linux-intel-acrn-uos_4.19.bb
@@ -1,5 +1,4 @@
 require linux-intel-acrn.inc
-require recipes-kernel/linux/linux-intel_4.19.bb
 
 SRC_URI_append = "  file://uos.cfg"
 

--- a/recipes-kernel/linux/linux-intel-acrn.inc
+++ b/recipes-kernel/linux/linux-intel-acrn.inc
@@ -1,6 +1,26 @@
 SUMMARY = "Linux Kernel with ACRN enabled"
 
-SRC_URI_append = "  file://0001-Add-the-plane-restrictionfor-SKL.-Otherwise-there-is.patch \
-                    file://0002-Add-the-change-for-gvt-g-on-SKL.patch"
-                    
-KERNEL_EXTRA_FEATURES += " cfg/hv-guest.scc  cfg/paravirt_kvm.scc "
+require recipes-kernel/linux/linux-intel.inc
+
+SRC_URI_append = "  file://perf-fix-build-with-binutils.patch \
+                    file://0001-menuconfig-mconf-cfg-Allow-specification-of-ncurses-.patch \
+                    file://0001-Add-the-plane-restrictionfor-SKL.-Otherwise-there-is.patch \
+                    file://0002-Add-the-change-for-gvt-g-on-SKL.patch \
+"
+
+KBRANCH = "4.19/base"
+KMETA_BRANCH = "yocto-4.19"
+
+LINUX_VERSION ?= "4.19.106"
+SRCREV_machine ?= "8ef641c89e3c2ff303eb362a7b77760dd2ed7e69"
+SRCREV_meta ?= "7cb520d405cd5ca8f21a333941fbc0861bbb36b0"
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
+
+DEPENDS += "elfutils-native openssl-native util-linux-native"
+
+KERNEL_EXTRA_FEATURES ?= "features/netfilter/netfilter.scc \
+                          features/security/security.scc  \
+                          cfg/hv-guest.scc \
+                          cfg/paravirt_kvm.scc \
+                          "

--- a/recipes-kernel/linux/linux-intel-rt-acrn-uos_4.19.bb
+++ b/recipes-kernel/linux/linux-intel-rt-acrn-uos_4.19.bb
@@ -1,7 +1,6 @@
 SUMMARY = "Linux Preempt RT Kernel with ACRN enabled (UOS)"
 
 require recipes-kernel/linux/linux-intel.inc
-require linux-intel-acrn.inc
 
 # PREFERRED_PROVIDER for virtual/kernel. This avoids errors when trying
 # to build multiple virtual/kernel providers.
@@ -10,11 +9,15 @@ python () {
         raise bb.parse.SkipPackage("Set PREFERRED_PROVIDER_virtual/kernel to linux-intel-rt-acrn-uos to enable it")
 }
 
-SRC_URI_append = "  file://uos.cfg"
-SRC_URI_append = "  file://uos-rt.cfg"
+SRC_URI_append = "  file://perf-fix-build-with-binutils.patch \
+                    file://0001-menuconfig-mconf-cfg-Allow-specification-of-ncurses-.patch \
+                    file://0001-Add-the-plane-restrictionfor-SKL.-Otherwise-there-is.patch \
+                    file://0002-Add-the-change-for-gvt-g-on-SKL.patch \
+                    file://uos.cfg \
+                    file://uos-rt.cfg \
+"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
-SRC_URI_append = " file://0001-menuconfig-mconf-cfg-Allow-specification-of-ncurses-.patch"
 
 KBRANCH = "4.19/preempt-rt"
 KMETA_BRANCH = "yocto-4.19"
@@ -28,3 +31,9 @@ SRCREV_meta ?= "4f5d761316a9cf14605e5d0cc91b53c1b2e9dc6a"
 LINUX_VERSION_EXTENSION = "-linux-intel-preempt-rt-acrn-uos"
 
 LINUX_KERNEL_TYPE = "preempt-rt"
+
+KERNEL_EXTRA_FEATURES ?= "features/netfilter/netfilter.scc \
+                          features/security/security.scc  \
+                          cfg/hv-guest.scc \
+                          cfg/paravirt_kvm.scc \
+                          "


### PR DESCRIPTION
add necessary part to linux-intel-acrn and acrn-kernel
as meta-intel drop linux-intel 4.19 for dunfell.

Signed-off-by: Lee Chee Yang <chee.yang.lee@intel.com>