### PR TITLE
linux-intel-acrn: dont depend on meta-intel linux-intel 5.4

### DIFF
--- a/recipes-kernel/linux/acrn-kernel-sos_4.19.bb
+++ b/recipes-kernel/linux/acrn-kernel-sos_4.19.bb
@@ -2,6 +2,6 @@ require acrn-kernel.inc
 
 SRC_URI_append = "  file://sos_4.19.scc"
 
-LINUX_VERSION_EXTENSION ?= "-acrn-kernel-sos"
+LINUX_VERSION_EXTENSION = "-acrn-kernel-sos"
 
 SUMMARY = "ACRN Kernel (SOS)"

--- a/recipes-kernel/linux/acrn-kernel-uos_4.19.bb
+++ b/recipes-kernel/linux/acrn-kernel-uos_4.19.bb
@@ -2,6 +2,6 @@ require acrn-kernel.inc
 
 SRC_URI_append = "  file://uos_4.19.scc"
 
-LINUX_VERSION_EXTENSION ?= "-acrn-kernel-uos"
+LINUX_VERSION_EXTENSION = "-acrn-kernel-uos"
 
 SUMMARY = "ACRN Kernel (UOS)"

--- a/recipes-kernel/linux/acrn-kernel.inc
+++ b/recipes-kernel/linux/acrn-kernel.inc
@@ -1,4 +1,4 @@
-require linux-intel-acrn.inc
+require linux-intel-acrn_4.19.inc
 
 KBRANCH = "release_1.6"
 
@@ -11,5 +11,3 @@ SRC_URI_remove = "file://0002-Add-the-change-for-gvt-g-on-SKL.patch"
 # tag: v1.6
 LINUX_VERSION = "4.19.106"
 SRCREV_machine = "02751a90703b49423905a7a1030816527f5e9c86"
-
-KERNEL_FEATURES_append = " cfg/hv-guest.scc  cfg/paravirt_kvm.scc "

--- a/recipes-kernel/linux/linux-intel-acrn-sos_4.19.bb
+++ b/recipes-kernel/linux/linux-intel-acrn-sos_4.19.bb
@@ -1,7 +1,7 @@
-require linux-intel-acrn.inc
+require linux-intel-acrn_4.19.inc
 
 SRC_URI_append = "  file://sos_4.19.scc"
 
-LINUX_VERSION_EXTENSION ?= "-linux-intel-acrn-sos"
+LINUX_VERSION_EXTENSION = "-linux-intel-acrn-sos"
 
 SUMMARY = "Linux Kernel with ACRN enabled (SOS)"

--- a/recipes-kernel/linux/linux-intel-acrn-sos_5.4.bb
+++ b/recipes-kernel/linux/linux-intel-acrn-sos_5.4.bb
@@ -1,12 +1,9 @@
-require recipes-kernel/linux/linux-intel_5.4.bb
+require linux-intel-acrn_5.4.inc
 
 SRC_URI_append = "  file://sos_5.4.scc"
 
-LINUX_VERSION_EXTENSION ?= "-linux-intel-acrn-sos"
+LINUX_VERSION_EXTENSION = "-linux-intel-acrn-sos"
 
 SUMMARY = "Linux Kernel with ACRN enabled (SOS)"
 
-KERNEL_FEATURES_append = " cfg/hv-guest.scc \
-                           cfg/paravirt_kvm.scc \
-                           sos_5.4.scc \
-"
+KERNEL_FEATURES_append = " sos_5.4.scc "

--- a/recipes-kernel/linux/linux-intel-acrn-uos_4.19.bb
+++ b/recipes-kernel/linux/linux-intel-acrn-uos_4.19.bb
@@ -1,7 +1,7 @@
-require linux-intel-acrn.inc
+require linux-intel-acrn_4.19.inc
 
 SRC_URI_append = "  file://uos_4.19.scc"
 
-LINUX_VERSION_EXTENSION ?= "-linux-intel-acrn-uos"
+LINUX_VERSION_EXTENSION = "-linux-intel-acrn-uos"
 
 SUMMARY = "Linux Kernel with ACRN enabled (UOS)"

--- a/recipes-kernel/linux/linux-intel-acrn-uos_5.4.bb
+++ b/recipes-kernel/linux/linux-intel-acrn-uos_5.4.bb
@@ -1,11 +1,7 @@
-require recipes-kernel/linux/linux-intel_5.4.bb
+require linux-intel-acrn_5.4.inc
 
 SRC_URI_append = "  file://uos_5.4.scc"
 
-LINUX_VERSION_EXTENSION ?= "-linux-intel-acrn-uos"
+LINUX_VERSION_EXTENSION = "-linux-intel-acrn-uos"
 
 SUMMARY = "Linux Kernel with ACRN enabled (UOS)"
-
-KERNEL_FEATURES_append = " cfg/hv-guest.scc \
-                           cfg/paravirt_kvm.scc \
-"

--- a/recipes-kernel/linux/linux-intel-acrn_4.19.inc
+++ b/recipes-kernel/linux/linux-intel-acrn_4.19.inc
@@ -1,4 +1,4 @@
-SUMMARY = "Linux Kernel with ACRN enabled"
+SUMMARY = "Linux Kernel 4.19 with ACRN enabled"
 
 require recipes-kernel/linux/linux-intel.inc
 

--- a/recipes-kernel/linux/linux-intel-acrn_5.4.inc
+++ b/recipes-kernel/linux/linux-intel-acrn_5.4.inc
@@ -1,0 +1,22 @@
+SUMMARY = "Linux Kernel 5.4 with ACRN enabled"
+
+require recipes-kernel/linux/linux-intel.inc
+
+SRC_URI_append = "  file://0001-menuconfig-mconf-cfg-Allow-specification-of-ncurses-.patch"
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
+
+KBRANCH = "5.4/yocto"
+KMETA_BRANCH = "yocto-5.4"
+
+LINUX_VERSION ?= "5.4.28"
+SRCREV_machine ?= "4726da64050d85576d3ea73ea9578865e3676f41"
+SRCREV_meta ?= "b8c82ba37370e4698ff0c42f3e54b8b4f2fb4ac0"
+
+DEPENDS += "elfutils-native openssl-native util-linux-native"
+
+KERNEL_FEATURES_append = "features/netfilter/netfilter.scc \
+                          features/security/security.scc  \
+                          cfg/hv-guest.scc \
+                          cfg/paravirt_kvm.scc \
+"


### PR DESCRIPTION
refactor linux-intel-acrn and drop dependency on meta-intel
linux-intel 5.4.

Signed-off-by: Lee Chee Yang <chee.yang.lee@intel.com>