### PR TITLE
acrn: dont mask all the LVT register

### DIFF
--- a/recipes-core/acrn/acrn-common.inc
+++ b/recipes-core/acrn/acrn-common.inc
@@ -7,6 +7,7 @@ SRC_URI = "git://github.com/projectacrn/acrn-hypervisor.git;branch=release_1.6 \
            file://paths.patch \
            file://0001-hypervisor-Makefile-do-not-strip.patch \
            file://0001-acrn-config-append-kconfig-setting-on-new-board.patch \
+           file://hv-lapic-minor-refine-about-init_lapic.patch \
 "
 
 # Snapshot tags are of the format:

--- a/recipes-core/acrn/files/hv-lapic-minor-refine-about-init_lapic.patch
+++ b/recipes-core/acrn/files/hv-lapic-minor-refine-about-init_lapic.patch
@@ -1,0 +1,41 @@
+From f8eda70bbfce39f755126d3180e38a59cfae5986 Mon Sep 17 00:00:00 2001
+From: Li Fei1 <fei1.li@intel.com>
+Date: Fri, 24 Apr 2020 16:32:30 +0800
+Subject: [PATCH] hv: lapic: minor refine about init_lapic
+
+According to SDM Vol 3, Chap 10.4.7.2 Local APIC State After It Has Been Software Disabled,
+The mask bits for all the LVT entries are set when the local APIC has been software disabled.
+So there's no need to mask all the LVT entries one by one.
+
+Tracked-On: #4550
+Signed-off-by: Li Fei1 <fei1.li@intel.com>
+
+Upstream-Status: Backport [https://github.com/projectacrn/acrn-hypervisor/commit/4c733708bf354274e3d0713af06fdbe787345b81]
+Signed-off-by: Lee Chee Yang <chee.yang.lee@intel.com>
+
+---
+ hypervisor/arch/x86/lapic.c | 11 +++--------
+ 1 file changed, 3 insertions(+), 8 deletions(-)
+
+diff --git a/hypervisor/arch/x86/lapic.c b/hypervisor/arch/x86/lapic.c
+index cb8eb3f4..b7999a7d 100644
+--- a/hypervisor/arch/x86/lapic.c
++++ b/hypervisor/arch/x86/lapic.c
+@@ -75,14 +75,9 @@ void early_init_lapic(void)
+ void init_lapic(uint16_t pcpu_id)
+ {
+ 	per_cpu(lapic_ldr, pcpu_id) = (uint32_t) msr_read(MSR_IA32_EXT_APIC_LDR);
+-	/* Mask all LAPIC LVT entries before enabling the local APIC */
+-	msr_write(MSR_IA32_EXT_APIC_LVT_CMCI, APIC_LVT_M);
+-	msr_write(MSR_IA32_EXT_APIC_LVT_TIMER, APIC_LVT_M);
+-	msr_write(MSR_IA32_EXT_APIC_LVT_THERMAL, APIC_LVT_M);
+-	msr_write(MSR_IA32_EXT_APIC_LVT_PMI, APIC_LVT_M);
+-	msr_write(MSR_IA32_EXT_APIC_LVT_LINT0, APIC_LVT_M);
+-	msr_write(MSR_IA32_EXT_APIC_LVT_LINT1, APIC_LVT_M);
+-	msr_write(MSR_IA32_EXT_APIC_LVT_ERROR, APIC_LVT_M);
++
++	/* Set the mask bits for all the LVT entries by disabling a local APIC software. */
++	msr_write(MSR_IA32_EXT_APIC_SIVR, 0UL);
+
+ 	/* Enable Local APIC */
+ 	/* TODO: add spurious-interrupt handler */


### PR DESCRIPTION
don't mask all the LVT register one by one this could be achieve
by disabling local APIC software.

Signed-off-by: Lee Chee Yang <chee.yang.lee@intel.com>