### PR TITLE
acrn: dont mask all the LVT register

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -7,5 +7,8 @@ BBFILE_COLLECTIONS += "meta-acrn"
 BBFILE_PATTERN_meta-acrn = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-acrn = "5"
 
+# Additional license directories.
+LICENSE_PATH += "${LAYERDIR}/custom-licenses"
+
 LAYERDEPENDS_meta-acrn = "core intel"
 LAYERSERIES_COMPAT_meta-acrn = "zeus dunfell"

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -8,4 +8,4 @@ BBFILE_PATTERN_meta-acrn = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-acrn = "5"
 
 LAYERDEPENDS_meta-acrn = "core intel"
-LAYERSERIES_COMPAT_meta-acrn = "dunfell"
+LAYERSERIES_COMPAT_meta-acrn = "zeus dunfell"

--- a/custom-licenses/Intel
+++ b/custom-licenses/Intel
@@ -1,0 +1,105 @@
+1. Copyright Notice
+
+Some or all of this work - Copyright (c) 1999 - 2017, Intel Corp.
+All rights reserved.
+
+2. License
+
+2.1. This is your license from Intel Corp. under its intellectual property
+rights. You may have additional license terms from the party that provided
+you this software, covering your right to use that party's intellectual
+property rights.
+
+2.2. Intel grants, free of charge, to any person ("Licensee") obtaining a
+copy of the source code appearing in this file ("Covered Code") an
+irrevocable, perpetual, worldwide license under Intel's copyrights in the
+base code distributed originally by Intel ("Original Intel Code") to copy,
+make derivatives, distribute, use and display any portion of the Covered
+Code in any form, with the right to sublicense such rights; and
+
+2.3. Intel grants Licensee a non-exclusive and non-transferable patent
+license (with the right to sublicense), under only those claims of Intel
+patents that are infringed by the Original Intel Code, to make, use, sell,
+offer to sell, and import the Covered Code and derivative works thereof
+solely to the minimum extent necessary to exercise the above copyright
+license, and in no event shall the patent license extend to any additions
+to or modifications of the Original Intel Code. No other license or right
+is granted directly or by implication, estoppel or otherwise;
+
+The above copyright and patent license is granted only if the following
+conditions are met:
+
+3. Conditions
+
+3.1. Redistribution of Source with Rights to Further Distribute Source.
+Redistribution of source code of any substantial portion of the Covered
+Code or modification with rights to further distribute source must include
+the above Copyright Notice, the above License, this list of Conditions,
+and the following Disclaimer and Export Compliance provision. In addition,
+Licensee must cause all Covered Code to which Licensee contributes to
+contain a file documenting the changes Licensee made to create that Covered
+Code and the date of any change. Licensee must include in that file the
+documentation of any changes made by any predecessor Licensee. Licensee
+must include a prominent statement that the modification is derived,
+directly or indirectly, from Original Intel Code.
+
+3.2. Redistribution of Source with no Rights to Further Distribute Source.
+Redistribution of source code of any substantial portion of the Covered
+Code or modification without rights to further distribute source must
+include the following Disclaimer and Export Compliance provision in the
+documentation and/or other materials provided with distribution. In
+addition, Licensee may not authorize further sublicense of source of any
+portion of the Covered Code, and must include terms to the effect that the
+license from Licensee to its licensee is limited to the intellectual
+property embodied in the software Licensee provides to its licensee, and
+not to intellectual property embodied in modifications its licensee may
+make.
+
+3.3. Redistribution of Executable. Redistribution in executable form of any
+substantial portion of the Covered Code or modification must reproduce the
+above Copyright Notice, and the following Disclaimer and Export Compliance
+provision in the documentation and/or other materials provided with the
+distribution.
+
+3.4. Intel retains all right, title, and interest in and to the Original
+Intel Code.
+
+3.5. Neither the name Intel nor any other trademark owned or controlled by
+Intel shall be used in advertising or otherwise to promote the sale, use or
+other dealings in products derived from or relating to the Covered Code
+without prior written authorization from Intel.
+
+4. Disclaimer and Export Compliance
+
+4.1. INTEL MAKES NO WARRANTY OF ANY KIND REGARDING ANY SOFTWARE PROVIDED
+HERE. ANY SOFTWARE ORIGINATING FROM INTEL OR DERIVED FROM INTEL SOFTWARE
+IS PROVIDED "AS IS," AND INTEL WILL NOT PROVIDE ANY SUPPORT, ASSISTANCE,
+INSTALLATION, TRAINING OR OTHER SERVICES. INTEL WILL NOT PROVIDE ANY
+UPDATES, ENHANCEMENTS OR EXTENSIONS. INTEL SPECIFICALLY DISCLAIMS ANY
+IMPLIED WARRANTIES OF MERCHANTABILITY, NONINFRINGEMENT AND FITNESS FOR A
+PARTICULAR PURPOSE.
+
+4.2. IN NO EVENT SHALL INTEL HAVE ANY LIABILITY TO LICENSEE, ITS LICENSEES
+OR ANY OTHER THIRD PARTY, FOR ANY LOST PROFITS, LOST DATA, LOSS OF USE OR
+COSTS OF PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES, OR FOR ANY INDIRECT,
+SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THIS AGREEMENT, UNDER ANY
+CAUSE OF ACTION OR THEORY OF LIABILITY, AND IRRESPECTIVE OF WHETHER INTEL
+HAS ADVANCE NOTICE OF THE POSSIBILITY OF SUCH DAMAGES. THESE LIMITATIONS
+SHALL APPLY NOTWITHSTANDING THE FAILURE OF THE ESSENTIAL PURPOSE OF ANY
+LIMITED REMEDY.
+
+4.3. Licensee shall not export, either directly or indirectly, any of this
+software or system incorporating such software without first obtaining any
+required license or other approval from the U. S. Department of Commerce or
+any other agency or department of the United States Government. In the
+event Licensee exports any such software from the United States or
+re-exports any such software from a foreign destination, Licensee shall
+ensure that the distribution and export/re-export of the software is in
+compliance with all laws, regulations, orders, or other restrictions of the
+U.S. Export Administration Regulations. Licensee agrees that neither it nor
+any of its subsidiaries will export/re-export any technical data, process,
+software, or service, directly or indirectly, to any country for which the
+United States government or any agency thereof requires an export license,
+other governmental approval, or letter of assurance, without first obtaining
+such license, approval or letter.
+

--- a/recipes-core/acrn/acrn-common.inc
+++ b/recipes-core/acrn/acrn-common.inc
@@ -7,6 +7,7 @@ SRC_URI = "git://github.com/projectacrn/acrn-hypervisor.git;branch=release_1.6 \
            file://paths.patch \
            file://0001-hypervisor-Makefile-do-not-strip.patch \
            file://0001-acrn-config-append-kconfig-setting-on-new-board.patch \
+           file://hv-lapic-minor-refine-about-init_lapic.patch \
 "
 
 # Snapshot tags are of the format:

--- a/recipes-core/acrn/acrn-tools.bb
+++ b/recipes-core/acrn/acrn-tools.bb
@@ -4,7 +4,7 @@ inherit pkgconfig systemd
 
 SRC_URI += "file://avoid-race-condition.patch"
 
-DEPENDS += "numactl systemd e2fsprogs libevent"
+DEPENDS += "numactl systemd e2fsprogs libevent libxml2 openssl"
 RDEPENDS_${PN} += "bash"
 
 do_compile() {

--- a/recipes-core/acrn/files/hv-lapic-minor-refine-about-init_lapic.patch
+++ b/recipes-core/acrn/files/hv-lapic-minor-refine-about-init_lapic.patch
@@ -1,0 +1,41 @@
+From f8eda70bbfce39f755126d3180e38a59cfae5986 Mon Sep 17 00:00:00 2001
+From: Li Fei1 <fei1.li@intel.com>
+Date: Fri, 24 Apr 2020 16:32:30 +0800
+Subject: [PATCH] hv: lapic: minor refine about init_lapic
+
+According to SDM Vol 3, Chap 10.4.7.2 Local APIC State After It Has Been Software Disabled,
+The mask bits for all the LVT entries are set when the local APIC has been software disabled.
+So there's no need to mask all the LVT entries one by one.
+
+Tracked-On: #4550
+Signed-off-by: Li Fei1 <fei1.li@intel.com>
+
+Upstream-Status: Backport [https://github.com/projectacrn/acrn-hypervisor/commit/4c733708bf354274e3d0713af06fdbe787345b81]
+Signed-off-by: Lee Chee Yang <chee.yang.lee@intel.com>
+
+---
+ hypervisor/arch/x86/lapic.c | 11 +++--------
+ 1 file changed, 3 insertions(+), 8 deletions(-)
+
+diff --git a/hypervisor/arch/x86/lapic.c b/hypervisor/arch/x86/lapic.c
+index cb8eb3f4..b7999a7d 100644
+--- a/hypervisor/arch/x86/lapic.c
++++ b/hypervisor/arch/x86/lapic.c
+@@ -75,14 +75,9 @@ void early_init_lapic(void)
+ void init_lapic(uint16_t pcpu_id)
+ {
+ 	per_cpu(lapic_ldr, pcpu_id) = (uint32_t) msr_read(MSR_IA32_EXT_APIC_LDR);
+-	/* Mask all LAPIC LVT entries before enabling the local APIC */
+-	msr_write(MSR_IA32_EXT_APIC_LVT_CMCI, APIC_LVT_M);
+-	msr_write(MSR_IA32_EXT_APIC_LVT_TIMER, APIC_LVT_M);
+-	msr_write(MSR_IA32_EXT_APIC_LVT_THERMAL, APIC_LVT_M);
+-	msr_write(MSR_IA32_EXT_APIC_LVT_PMI, APIC_LVT_M);
+-	msr_write(MSR_IA32_EXT_APIC_LVT_LINT0, APIC_LVT_M);
+-	msr_write(MSR_IA32_EXT_APIC_LVT_LINT1, APIC_LVT_M);
+-	msr_write(MSR_IA32_EXT_APIC_LVT_ERROR, APIC_LVT_M);
++
++	/* Set the mask bits for all the LVT entries by disabling a local APIC software. */
++	msr_write(MSR_IA32_EXT_APIC_SIVR, 0UL);
+
+ 	/* Enable Local APIC */
+ 	/* TODO: add spurious-interrupt handler */

--- a/recipes-core/packagegroups/packagegroup-acrn.bb
+++ b/recipes-core/packagegroups/packagegroup-acrn.bb
@@ -1,6 +1,6 @@
 SUMMARY = "ACRN hypervisor"
 
-inherit packagegroup features_check
+inherit packagegroup ${@bb.utils.contains('LAYERSERIES_CORENAMES', 'zeus', 'distro_features_check', 'features_check', d)}
 
 # Currently requires systemd as the networking glue is systemd-specific
 REQUIRED_DISTRO_FEATURES = "systemd"

--- a/recipes-extended/acpica/acpica_20200214.bb
+++ b/recipes-extended/acpica/acpica_20200214.bb
@@ -1,0 +1,53 @@
+# To support 1.4 or higher ACRN Hypervisor versions, ver. 20191018 or
+# higher version of acpica required. So to build aginst 'zeus' release
+# carrying this version
+
+SUMMARY = "ACPICA tools for the development and debug of ACPI tables"
+DESCRIPTION = "The ACPI Component Architecture (ACPICA) project provides an \
+OS-independent reference implementation of the Advanced Configuration and \
+Power Interface Specification (ACPI). ACPICA code contains those portions of \
+ACPI meant to be directly integrated into the host OS as a kernel-resident \
+subsystem, and a small set of tools to assist in developing and debugging \
+ACPI tables."
+
+HOMEPAGE = "http://www.acpica.org/"
+SECTION = "console/tools"
+
+LICENSE = "Intel | BSD | GPLv2"
+LIC_FILES_CHKSUM = "file://source/compiler/aslcompile.c;beginline=7;endline=150;md5=6adbcb81e9ee6ae50c569b94fe12f7c5"
+
+COMPATIBLE_HOST = "(i.86|x86_64|arm|aarch64).*-linux"
+
+DEPENDS = "m4-native flex-native bison-native"
+
+SRC_URI = "https://acpica.org/sites/acpica/files/acpica-unix-${PV}.tar.gz"
+SRC_URI[md5sum] = "3505ba6170b77db1399eae0e2a959113"
+SRC_URI[sha256sum] = "e77ab9f8557ca104f6e8f49efaa8eead29f78ca11cadfc8989012469ecc0738e"
+UPSTREAM_CHECK_URI = "https://acpica.org/downloads"
+
+S = "${WORKDIR}/acpica-unix-${PV}"
+
+inherit update-alternatives
+
+ALTERNATIVE_PRIORITY = "100"
+ALTERNATIVE_${PN} = "acpixtract acpidump"
+
+EXTRA_OEMAKE = "CC='${CC}' \
+                OPT_CFLAGS=-Wall \
+                DESTDIR=${D} \
+                PREFIX=${prefix} \
+                INSTALLDIR=${bindir} \
+                INSTALLFLAGS= \
+                "
+
+do_install() {
+    oe_runmake install
+}
+
+# iasl*.bb is a subset of this recipe, so RREPLACE it
+PROVIDES = "iasl"
+RPROVIDES_${PN} += "iasl"
+RREPLACES_${PN} += "iasl"
+RCONFLICTS_${PN} += "iasl"
+
+BBCLASSEXTEND = "native"

--- a/recipes-kernel/linux/acrn-kernel-sos_4.19.bb
+++ b/recipes-kernel/linux/acrn-kernel-sos_4.19.bb
@@ -2,6 +2,6 @@ require acrn-kernel.inc
 
 SRC_URI_append = "  file://sos_4.19.scc"
 
-LINUX_VERSION_EXTENSION ?= "-acrn-kernel-sos"
+LINUX_VERSION_EXTENSION = "-acrn-kernel-sos"
 
 SUMMARY = "ACRN Kernel (SOS)"

--- a/recipes-kernel/linux/acrn-kernel-uos_4.19.bb
+++ b/recipes-kernel/linux/acrn-kernel-uos_4.19.bb
@@ -2,6 +2,6 @@ require acrn-kernel.inc
 
 SRC_URI_append = "  file://uos_4.19.scc"
 
-LINUX_VERSION_EXTENSION ?= "-acrn-kernel-uos"
+LINUX_VERSION_EXTENSION = "-acrn-kernel-uos"
 
 SUMMARY = "ACRN Kernel (UOS)"

--- a/recipes-kernel/linux/acrn-kernel.inc
+++ b/recipes-kernel/linux/acrn-kernel.inc
@@ -1,4 +1,4 @@
-require linux-intel-acrn.inc
+require linux-intel-acrn_4.19.inc
 
 KBRANCH = "release_1.6"
 
@@ -11,5 +11,3 @@ SRC_URI_remove = "file://0002-Add-the-change-for-gvt-g-on-SKL.patch"
 # tag: v1.6
 LINUX_VERSION = "4.19.106"
 SRCREV_machine = "02751a90703b49423905a7a1030816527f5e9c86"
-
-KERNEL_FEATURES_append = " cfg/hv-guest.scc  cfg/paravirt_kvm.scc "

--- a/recipes-kernel/linux/linux-intel-acrn-sos_4.19.bb
+++ b/recipes-kernel/linux/linux-intel-acrn-sos_4.19.bb
@@ -1,7 +1,7 @@
-require linux-intel-acrn.inc
+require linux-intel-acrn_4.19.inc
 
 SRC_URI_append = "  file://sos_4.19.scc"
 
-LINUX_VERSION_EXTENSION ?= "-linux-intel-acrn-sos"
+LINUX_VERSION_EXTENSION = "-linux-intel-acrn-sos"
 
 SUMMARY = "Linux Kernel with ACRN enabled (SOS)"

--- a/recipes-kernel/linux/linux-intel-acrn-sos_5.4.bb
+++ b/recipes-kernel/linux/linux-intel-acrn-sos_5.4.bb
@@ -1,12 +1,9 @@
-require recipes-kernel/linux/linux-intel_5.4.bb
+require linux-intel-acrn_5.4.inc
 
 SRC_URI_append = "  file://sos_5.4.scc"
 
-LINUX_VERSION_EXTENSION ?= "-linux-intel-acrn-sos"
+LINUX_VERSION_EXTENSION = "-linux-intel-acrn-sos"
 
 SUMMARY = "Linux Kernel with ACRN enabled (SOS)"
 
-KERNEL_FEATURES_append = " cfg/hv-guest.scc \
-                           cfg/paravirt_kvm.scc \
-                           sos_5.4.scc \
-"
+KERNEL_FEATURES_append = " sos_5.4.scc "

--- a/recipes-kernel/linux/linux-intel-acrn-uos_4.19.bb
+++ b/recipes-kernel/linux/linux-intel-acrn-uos_4.19.bb
@@ -1,7 +1,7 @@
-require linux-intel-acrn.inc
+require linux-intel-acrn_4.19.inc
 
 SRC_URI_append = "  file://uos_4.19.scc"
 
-LINUX_VERSION_EXTENSION ?= "-linux-intel-acrn-uos"
+LINUX_VERSION_EXTENSION = "-linux-intel-acrn-uos"
 
 SUMMARY = "Linux Kernel with ACRN enabled (UOS)"

--- a/recipes-kernel/linux/linux-intel-acrn-uos_5.4.bb
+++ b/recipes-kernel/linux/linux-intel-acrn-uos_5.4.bb
@@ -1,11 +1,7 @@
-require recipes-kernel/linux/linux-intel_5.4.bb
+require linux-intel-acrn_5.4.inc
 
 SRC_URI_append = "  file://uos_5.4.scc"
 
-LINUX_VERSION_EXTENSION ?= "-linux-intel-acrn-uos"
+LINUX_VERSION_EXTENSION = "-linux-intel-acrn-uos"
 
 SUMMARY = "Linux Kernel with ACRN enabled (UOS)"
-
-KERNEL_FEATURES_append = " cfg/hv-guest.scc \
-                           cfg/paravirt_kvm.scc \
-"

--- a/recipes-kernel/linux/linux-intel-acrn_4.19.inc
+++ b/recipes-kernel/linux/linux-intel-acrn_4.19.inc
@@ -1,4 +1,4 @@
-SUMMARY = "Linux Kernel with ACRN enabled"
+SUMMARY = "Linux Kernel 4.19 with ACRN enabled"
 
 require recipes-kernel/linux/linux-intel.inc
 

--- a/recipes-kernel/linux/linux-intel-acrn_5.4.inc
+++ b/recipes-kernel/linux/linux-intel-acrn_5.4.inc
@@ -1,0 +1,22 @@
+SUMMARY = "Linux Kernel 5.4 with ACRN enabled"
+
+require recipes-kernel/linux/linux-intel.inc
+
+SRC_URI_append = "  file://0001-menuconfig-mconf-cfg-Allow-specification-of-ncurses-.patch"
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
+
+KBRANCH = "5.4/yocto"
+KMETA_BRANCH = "yocto-5.4"
+
+LINUX_VERSION ?= "5.4.28"
+SRCREV_machine ?= "4726da64050d85576d3ea73ea9578865e3676f41"
+SRCREV_meta ?= "b8c82ba37370e4698ff0c42f3e54b8b4f2fb4ac0"
+
+DEPENDS += "elfutils-native openssl-native util-linux-native"
+
+KERNEL_FEATURES_append = "features/netfilter/netfilter.scc \
+                          features/security/security.scc  \
+                          cfg/hv-guest.scc \
+                          cfg/paravirt_kvm.scc \
+"


### PR DESCRIPTION
don't mask all the LVT register one by one this could be achieve
by disabling local APIC software.

Signed-off-by: Lee Chee Yang <chee.yang.lee@intel.com>