### PR TITLE
acrn-hypervisor: build with customized xml file

### DIFF
--- a/recipes-core/acrn/acrn-hypervisor.bb
+++ b/recipes-core/acrn/acrn-hypervisor.bb
@@ -2,10 +2,12 @@ require acrn-common.inc
 
 ACRN_BOARD ?= "nuc7i7dnb"
 ACRN_SCENARIO  ?= "industry"
+ACRN_BOARD_FILE ?= ""
+ACRN_SCENARIO_FILE ?= ""
 
 EXTRA_OEMAKE += "HV_OBJDIR=${B}/hypervisor "
-EXTRA_OEMAKE += "BOARD=${ACRN_BOARD} SCENARIO=${ACRN_SCENARIO}"
-EXTRA_OEMAKE += "BOARD_FILE=${S}/misc/acrn-config/xmls/board-xmls/${ACRN_BOARD}.xml SCENARIO_FILE=${S}/misc/acrn-config/xmls/config-xmls/${ACRN_BOARD}/${ACRN_SCENARIO}.xml"
+EXTRA_OEMAKE += "${@bb.utils.contains('ACRN_BOARD_FILE', '', 'BOARD_FILE=${ACRN_BOARD_FILE}', 'BOARD=${ACRN_BOARD}', d)}"
+EXTRA_OEMAKE += "${@bb.utils.contains('ACRN_SCENARIO_FILE', '', 'SCENARIO_FILE=${ACRN_SCENARIO_FILE}', 'SCENARIO=${ACRN_SCENARIO}', d)} "
 
 SRC_URI_append_class-target += "file://hypervisor-dont-build-pre_build.patch"
 


### PR DESCRIPTION
Introduce ACRN_BOARD_FILE and ACRN_SCENARIO_FILE to allow select customized xml for SCENARIO_FILE and BOARD_FILE.

Both ACRN_BOARD_FILE and ACRN_SCENARIO_FILE are set to blank by default which mean build against "source code" method by default.

These 2 variable need to either both set to blank or both set to xml file. Based on the board and scenario in the xml file, update ACRN_SCENARIO and ACRN_FILE in local.conf accordingly.

To build using customized xml, set below item in local.conf :
ACRN_BOARD_FILE="<full-path-to-xml>"
ACRN_SCENARIO_FILE="<full-path-to-xml>"
ACRN_BOARD = "<board-in-xml>"
ACRN_SCENARIO = "<scenario-in-xml>"
