### PR TITLE
.travis.yml: switch to Ubuntu 18.04 on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: bionic
 language: python
 python:
 - "3.6"


### PR DESCRIPTION
By default CI builds on Ubuntu 16.04, where build complains for gcc version.
Routing build to Ubuntu 18.04


Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>