### PR TITLE
acrn-demo-uos: remove maxcpus=1

### DIFF
--- a/conf/distro/acrn-demo-uos.conf
+++ b/conf/distro/acrn-demo-uos.conf
@@ -14,5 +14,5 @@ IMAGE_FSTYPES = "wic ext4"
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += "networkd-config"
 
 LINUX_RT_APPEND ?= "${@bb.utils.contains('PREFERRED_PROVIDER_virtual/kernel', 'linux-intel-rt-acrn-uos', 'clocksource=tsc tsc=reliable x2apic_phys processor.max_cstate=0 intel_idle.max_cstate=0 intel_pstate=disable mce=ignore_ce audit=0 isolcpus=nohz,domain,1 nohz_full=1 rcu_nocbs=1 nosoftlockup idle=poll irqaffinity=0', '', d)}"
-APPEND += " rw maxcpus=1 nohpet console=hvc0 console=ttyS0 no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable \
+APPEND += " rw nohpet console=hvc0 console=ttyS0 no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable \
             i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x070F00 ${LINUX_RT_APPEND}"


### PR DESCRIPTION
RT uos need 2 cpu cores to start.

Signed-off-by: Gao Junhao <junhao.gao@intel.com>