### PR TITLE
acrn-hypervisor: fix build failure due to gcc-10

### DIFF
--- a/recipes-core/acrn/acrn-common.inc
+++ b/recipes-core/acrn/acrn-common.inc
@@ -7,6 +7,7 @@ SRC_URI = "git://github.com/projectacrn/acrn-hypervisor.git;branch=release_1.6 \
            file://paths.patch \
            file://0001-hypervisor-Makefile-do-not-strip.patch \
            file://hv-lapic-minor-refine-about-init_lapic.patch \
+           file://gcc-10-disable-array-bounds-warning-for-now.patch \
 "
 
 # Snapshot tags are of the format:

--- a/recipes-core/acrn/files/gcc-10-disable-array-bounds-warning-for-now.patch
+++ b/recipes-core/acrn/files/gcc-10-disable-array-bounds-warning-for-now.patch
@@ -1,0 +1,34 @@
+From 5e864385d4a5e8816eaaa43c35935c5dbc72125e Mon Sep 17 00:00:00 2001
+From: Naveen Saini <naveen.kumar.saini@intel.com>
+Date: Fri, 15 May 2020 18:18:44 +0800
+Subject: [PATCH] gcc-10: disable 'array-bounds' warning for now
+
+Build failure log:
+arch/x86/page.c: In function 'init_ept_mem_ops':
+arch/x86/page.c:240:48: error: array subscript is outside array bounds of 'struct page[0][1]' [-Werror=array-bounds]
+240 | ept_pages_info[vm_id].ept.nworld_pml4_base = pre_uos_nworld_pml4_pages[vm_id];
+
+Suppress the warning until fix is not available in upstream.
+
+Upstream-Status: Pending
+
+Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>
+---
+ hypervisor/Makefile | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/hypervisor/Makefile b/hypervisor/Makefile
+index 45a45c9e..4b9a22ae 100644
+--- a/hypervisor/Makefile
++++ b/hypervisor/Makefile
+@@ -79,6 +79,7 @@ CFLAGS += -m64 -mno-mmx -mno-sse -mno-sse2 -mno-80387 -mno-fp-ret-in-387
+ CFLAGS += -mno-red-zone -mpopcnt
+ CFLAGS += -nostdinc -nostdlib -fno-common
+ CFLAGS += -Werror
++CFLAGS += -Wno-array-bounds
+ CFLAGS += -O2
+ ifeq (y, $(CONFIG_RELOC))
+ CFLAGS += -fpie
+-- 
+2.17.1
+


### PR DESCRIPTION
Disable 'array-bounds' warning for now.

Issue:
https://github.com/projectacrn/acrn-hypervisor/issues/4810

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>