### PR TITLE
linux-intel-rt-acrn-uos: add v5.4 recipe

### DIFF
--- a/conf/distro/acrn-demo-uos.conf
+++ b/conf/distro/acrn-demo-uos.conf
@@ -5,6 +5,7 @@ DISTRO_NAME += "(UOS)"
 
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-intel-acrn-uos"
 PREFERRED_VERSION_linux-intel-acrn-uos ?= "5.4%"
+PREFERRED_VERSION_linux-intel-rt-acrn-uos ?= "5.4%"
 
 # UOS images are always ext4
 IMAGE_FSTYPES = "wic ext4"

--- a/recipes-kernel/linux/files/uos_rt_5.4.scc
+++ b/recipes-kernel/linux/files/uos_rt_5.4.scc
@@ -1,0 +1,6 @@
+define KFEATURE_DESCRIPTION "Add required kernel features for 5.4 UOS Preempt RT kernel"
+define KFEATURE_COMPATIBILITY board
+
+kconf non-hardware acrn-common.cfg
+kconf non-hardware uos_5.4.cfg
+kconf non-hardware uos-rt.cfg

--- a/recipes-kernel/linux/linux-intel-rt-acrn-uos_5.4.bb
+++ b/recipes-kernel/linux/linux-intel-rt-acrn-uos_5.4.bb
@@ -1,0 +1,35 @@
+SUMMARY = "Linux Preempt RT Kernel with ACRN enabled (UOS)"
+
+require recipes-kernel/linux/linux-intel.inc
+
+# PREFERRED_PROVIDER for virtual/kernel. This avoids errors when trying
+# to build multiple virtual/kernel providers.
+python () {
+    if d.getVar("KERNEL_PACKAGE_NAME", True) == "kernel" and d.getVar("PREFERRED_PROVIDER_virtual/kernel") != "linux-intel-rt-acrn-uos":
+        raise bb.parse.SkipPackage("Set PREFERRED_PROVIDER_virtual/kernel to linux-intel-rt-acrn-uos to enable it")
+}
+
+SRC_URI_append = "  file://0001-menuconfig-mconf-cfg-Allow-specification-of-ncurses-.patch \
+                    file://uos_rt_5.4.scc \
+"
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
+
+KBRANCH = "5.4/preempt-rt"
+KMETA_BRANCH = "yocto-5.4"
+
+DEPENDS += "elfutils-native openssl-native util-linux-native"
+
+LINUX_VERSION ?= "5.4.39"
+SRCREV_machine ?= "ddb02394d5c1e41e8d0ef2b67f256e0fcf57c2eb"
+SRCREV_meta ?= "b8c82ba37370e4698ff0c42f3e54b8b4f2fb4ac0"
+
+LINUX_VERSION_EXTENSION = "-linux-intel-preempt-rt-acrn-uos"
+
+LINUX_KERNEL_TYPE = "preempt-rt"
+
+KERNEL_FEATURES_append = "features/netfilter/netfilter.scc \
+                          features/security/security.scc  \
+                          cfg/hv-guest.scc \
+                          cfg/paravirt_kvm.scc \
+"


### PR DESCRIPTION
add v5.4 linux-intel-rt-acrn-uos kernel and set it as default
UOS rt kernel version.

Signed-off-by: Chee Yang Lee <chee.yang.lee@intel.com>
Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>