### PR TITLE
acrn-hypervisor: fix build for whl-ipc-i7

### DIFF
--- a/recipes-core/acrn/acrn-common.inc
+++ b/recipes-core/acrn/acrn-common.inc
@@ -10,7 +10,7 @@ SRC_URI = "git://github.com/projectacrn/acrn-hypervisor.git;branch=${SRCBRANCH} 
 # Snapshot tags are of the format:
 # acrn-<year>w<week>.<day>-<timestamp><pass|fail>
 PV = "2.0rc"
-SRCREV = "e3fe3da2732682cbb53e79675851ab33c54b7d8b"
+SRCREV = "70f7e2239fbbd2431337c7cf5629bea664fdf3ca"
 SRCBRANCH = "release_2.0"
 
 UPSTREAM_CHECK_GITTAGREGEX = "^v(?P<pver>\d+(\.\d+)+)$"

--- a/recipes-core/acrn/acrn-hypervisor.bb
+++ b/recipes-core/acrn/acrn-hypervisor.bb
@@ -15,6 +15,13 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 DEPENDS += "python3-kconfiglib-native"
 DEPENDS += "${@'gnu-efi' if d.getVar('ACRN_FIRMWARE') == 'uefi' else ''}"
 
+do_configure() {
+	cat <<-EOF >> ${S}/hypervisor/arch/x86/configs/${ACRN_BOARD}.config
+CONFIG_BOARD="${ACRN_BOARD}"
+EOF
+	cat ${S}/hypervisor/arch/x86/configs/${ACRN_BOARD}.config
+}
+
 do_compile() {
 	oe_runmake -C hypervisor
 	if [ "${ACRN_FIRMWARE}" = "uefi" ]; then


### PR DESCRIPTION
In yocto build env, during build, kconfig not able to provide defconfig_filename(defconfig), which is set to default path 'arch/x86/configs/$BOARD.config' by hypervisor/arch/x86/Kconfig.

So in result, during make oldconfig, not able to generate .config

To fix this issue, creating harmless sample .config before compilation, which gets patched later.

Also has patch to update to latest acrn release 2.0 RC commit.

 Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>
