### PR TITLE
acrn-demo-sos: fix memmap on grub-efi

### DIFF
--- a/conf/distro/acrn-demo-sos.conf
+++ b/conf/distro/acrn-demo-sos.conf
@@ -12,7 +12,7 @@ PREFERRED_PROVIDER_nativesdk-libvirt = "nativesdk-acrn-libvirt"
 
 
 # ACRN hypervisor log setting, sensible defaults
-LINUX_ACRN_APPEND ?= "hvlog=2M@0xE00000 memmap=2M$0xE00000"
+LINUX_ACRN_APPEND ?= "hvlog=2M@0xE00000 ${@bb.utils.contains('EFI_PROVIDER','grub-efi','memmap=2M\$0xE00000','memmap=2M$0xE00000',d)} "
 # GVT enabling. SOS has pipe 0, one UOS has the rest.
 LINUX_GVT_APPEND ?= "i915.enable_gvt=1 i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.domain_scaler_owner=0x011100"
 


### PR DESCRIPTION
fix unable to boot issue on grub-efi due to special character in
memmap.

Signed-off-by: Lee Chee Yang <chee.yang.lee@intel.com>