### PR TITLE
libvirt: add bbappend

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -12,3 +12,8 @@ LICENSE_PATH += "${LAYERDIR}/custom-licenses"
 
 LAYERDEPENDS_meta-acrn = "core intel"
 LAYERSERIES_COMPAT_meta-acrn = "zeus dunfell"
+
+BBFILES_DYNAMIC += " \
+    virtualization-layer:${LAYERDIR}/dynamic-layers/virtualization-layer/*/*/*.bb \
+    virtualization-layer:${LAYERDIR}/dynamic-layers/virtualization-layer/*/*/*.bbappend \
+"

--- a/dynamic-layers/virtualization-layer/recipes-extended/libvirt/libvirt_6.1.0.bbappend
+++ b/dynamic-layers/virtualization-layer/recipes-extended/libvirt/libvirt_6.1.0.bbappend
@@ -1,0 +1,21 @@
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI_remove = "http://libvirt.org/sources/libvirt-${PV}.tar.xz;name=libvirt"
+SRC_URI_remove = "file://0001-to-fix-build-error.patch"
+SRC_URI_prepend = "git://github.com/projectacrn/acrn-libvirt.git;branch=${SRCBRANCH};destsuffix=libvirt-${PV};name=libvirt \
+           git://gitlab.com/keycodemap/keycodemapdb.git;protocol=https;destsuffix=libvirt-${PV}/src/keycodemapdb;name=keycodemapdb "
+
+
+SRCBRANCH = "dev-acrn-v6.1.0"
+# with acrn v6.1.0
+SRCREV_libvirt = "51be5dbc7dc8fe3142ec23aebf314aa23e109554"
+SRCREV_keycodemapdb = "27acf0ef828bf719b2053ba398b195829413dbdd"
+
+EXTRA_OECONF_append = " --disable-werror"
+do_configure_prepend () {
+    olddir=`pwd`
+    cd ${S}
+    autoreconf --verbose --force --install
+    cd $olddir
+}


### PR DESCRIPTION
Fetching source from acrn-libvirt repo, which has ACRN HV support.

Added do_configure and source uri for keycodemapdb

Dropped patches, which is not required anymore.

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>