### PR TITLE
acrn-demo.inc: set acrn-libvirt as PREFERRED_PROVIDER

### DIFF
--- a/conf/distro/acrn-demo-sos.conf
+++ b/conf/distro/acrn-demo-sos.conf
@@ -6,10 +6,6 @@ DISTRO_NAME += "(SOS)"
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-intel-acrn-sos"
 PREFERRED_VERSION_linux-intel-acrn-sos ?= "5.4%"
 
-PREFERRED_PROVIDER_libvirt = "acrn-libvirt"
-PREFERRED_PROVIDER_libvirt-native = "acrn-libvirt-native"
-PREFERRED_PROVIDER_nativesdk-libvirt = "nativesdk-acrn-libvirt"
-
 
 # ACRN hypervisor log setting, sensible defaults
 LINUX_ACRN_APPEND ?= "hvlog=2M@0xE00000 ${@bb.utils.contains('EFI_PROVIDER','grub-efi','memmap=2M\$0xE00000','memmap=2M$0xE00000',d)} "

--- a/conf/distro/include/acrn-demo.inc
+++ b/conf/distro/include/acrn-demo.inc
@@ -26,3 +26,7 @@ TCLIBCAPPEND = ""
 # The SOS needs to use networkd to get the bridges working correctly, and
 # networkd makes guest networking trivial.
 NETWORK_MANAGER = "systemd"
+
+PREFERRED_PROVIDER_libvirt = "acrn-libvirt"
+PREFERRED_PROVIDER_libvirt-native = "acrn-libvirt-native"
+PREFERRED_PROVIDER_nativesdk-libvirt = "nativesdk-acrn-libvirt"


### PR DESCRIPTION
It is applicable for both SOS and UOS

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>