### PR TITLE
linux-intel-acrn/5.4: update to 5.4.46

### DIFF
--- a/recipes-kernel/linux/linux-intel-acrn_5.4.inc
+++ b/recipes-kernel/linux/linux-intel-acrn_5.4.inc
@@ -9,8 +9,8 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 KBRANCH = "5.4/yocto"
 KMETA_BRANCH = "yocto-5.4"
 
-LINUX_VERSION ?= "5.4.39"
-SRCREV_machine ?= "2128351fa067ab2e14ca1862445925dec1b33159"
+LINUX_VERSION ?= "5.4.46"
+SRCREV_machine ?= "d0153c6341e035bf51514f537de3af607a453798"
 SRCREV_meta ?= "b8c82ba37370e4698ff0c42f3e54b8b4f2fb4ac0"
 
 DEPENDS += "elfutils-native openssl-native util-linux-native"


### PR DESCRIPTION
Add PCH slow clock wa for EHL GPU flr
* tag 'v5.4.46': (35 commits)
Linux 5.4.46
Revert "net/mlx5: Annotate mutex destroy for root ns"
uprobes: ensure that uprobe->offset and ->ref_ctr_offset are properly aligned
x86/speculation: Add Ivy Bridge to affected list
x86/speculation: Add SRBDS vulnerability and mitigation documentation
x86/speculation: Add Special Register Buffer Data Sampling (SRBDS) mitigation
x86/cpu: Add 'table' argument to cpu_matches()
x86/cpu: Add a steppings field to struct x86_cpu_id
x86/speculation/spectre_v2: Exclude Zhaoxin CPUs from SPECTRE_V2
nvmem: qfprom: remove incorrect write support
CDC-ACM: heed quirk also in error handling
staging: rtl8712: Fix IEEE80211_ADDBA_PARAM_BUF_SIZE_MASK
tty: hvc_console, fix crashes on parallel open/close
vt: keyboard: avoid signed integer overflow in k_ascii
usb: musb: Fix runtime PM imbalance on error
usb: musb: start session in resume for host port
iio: adc: stm32-adc: fix a wrong error message when probing interrupts
iio:chemical:pms7003: Fix timestamp alignment and prevent data leak.
iio: vcnl4000: Fix i2c swapped word reading.
iio:chemical:sps30: Fix timestamp alignment
...

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>