### PR TITLE
acrn-dev: add recipes

### DIFF
--- a/conf/distro/acrn-demo-sos.conf
+++ b/conf/distro/acrn-demo-sos.conf
@@ -6,6 +6,10 @@ DISTRO_NAME += "(SOS)"
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-intel-acrn-sos"
 PREFERRED_VERSION_linux-intel-acrn-sos ?= "5.4%"
 
+PREFERRED_PROVIDER_acrn-hypervisor ?= "acrn-hypervisor"
+PREFERRED_PROVIDER_acrn-devicemodel ?= "acrn-devicemodel"
+PREFERRED_PROVIDER_acrn-tools ?= "acrn-tools"
+
 # ACRN hypervisor log setting, sensible defaults
 LINUX_ACRN_APPEND ?= "hvlog=2M@0xE00000 ${@bb.utils.contains('EFI_PROVIDER','grub-efi','memmap=2M\$0xE00000','memmap=2M$0xE00000',d)} "
 # GVT enabling. SOS has pipe 0, one UOS has the rest.

--- a/recipes-core/acrn/acrn-common-dev.inc
+++ b/recipes-core/acrn/acrn-common-dev.inc
@@ -1,0 +1,4 @@
+SRC_URI = "git://github.com/projectacrn/acrn-hypervisor.git;branch=release_2.0 "
+
+PV = "2.0rc"
+SRCREV = "e0a101d9f05bb0984cbb505067a04fa28ecdc7d5"

--- a/recipes-core/acrn/acrn-devicemodel-dev.bb
+++ b/recipes-core/acrn/acrn-devicemodel-dev.bb
@@ -1,0 +1,8 @@
+require acrn-devicemodel.bb
+require acrn-common-dev.inc
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/acrn-devicemodel:"
+SRC_URI += "file://dont-build-tools.patch"
+
+PROVIDES = "acrn-devicemodel"
+RPROVIDES_${PN} += "acrn-devicemodel"

--- a/recipes-core/acrn/acrn-hypervisor-dev.bb
+++ b/recipes-core/acrn/acrn-hypervisor-dev.bb
@@ -1,0 +1,5 @@
+require acrn-hypervisor.bb
+require acrn-common-dev.inc
+
+PROVIDES = "acrn-hypervisor"
+RPROVIDES_${PN} += "acrn-hypervisor"

--- a/recipes-core/acrn/acrn-tools-dev.bb
+++ b/recipes-core/acrn/acrn-tools-dev.bb
@@ -1,0 +1,7 @@
+require acrn-tools.bb
+require acrn-common-dev.inc
+
+SRC_URI_remove = "file://avoid-race-condition.patch"
+
+PROVIDES = "acrn-tools"
+RPROVIDES_${PN} += "acrn-tools"


### PR DESCRIPTION
Add acrn dev recipes, which can be used to build latest
available ACRN release.

Currently points to ACRN 2.0 RC.

To select the acrn-dev provider, add below in local.conf

PREFERRED_PROVIDER_acrn-hypervisor = "acrn-hypervisor-dev"
PREFERRED_PROVIDER_acrn-devicemodel = "acrn-devicemodel-dev"
PREFERRED_PROVIDER_acrn-tools = "acrn-tools-dev"

You might need to clean up your previous build first, as Yocto does not
support provider switching.

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>