### PR TITLE
acrn-dems-sos.conf: maintain different hvlog parameters

### DIFF
--- a/conf/distro/acrn-demo-sos.conf
+++ b/conf/distro/acrn-demo-sos.conf
@@ -11,7 +11,9 @@ PREFERRED_PROVIDER_acrn-devicemodel ?= "acrn-devicemodel"
 PREFERRED_PROVIDER_acrn-tools ?= "acrn-tools"
 
 # ACRN hypervisor log setting, sensible defaults
-LINUX_ACRN_APPEND ?= "hvlog=2M@0xE00000 ${@bb.utils.contains('EFI_PROVIDER','grub-efi','memmap=2M\$0xE00000','memmap=2M$0xE00000',d)} "
+HVLOG_PARAM = "hvlog=2M@0xE00000 ${@bb.utils.contains('EFI_PROVIDER','grub-efi','memmap=2M\$0xE00000','memmap=2M$0xE00000',d)} "
+LINUX_ACRN_APPEND ?= "${@bb.utils.contains('PREFERRED_PROVIDER_acrn-hypervisor','acrn-hypervisor','hvlog=2M@0x1FE00000 ','${HVLOG_PARAM}',d)}"
+
 # GVT enabling. SOS has pipe 0, one UOS has the rest.
 LINUX_GVT_APPEND ?= "i915.enable_gvt=1 i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.domain_scaler_owner=0x011100"
 


### PR DESCRIPTION
Supported boot parameters for acrn 1.6.1:
hvlog=2M@0x1FE00000

Supported boot parameters for acrn 2.0rc:
hvlog=2M@0xE00000 memmap=2M$0xE00000

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>