### PR TITLE
acrn-libvirt: add recipe

### DIFF
--- a/conf/distro/acrn-demo-sos.conf
+++ b/conf/distro/acrn-demo-sos.conf
@@ -10,6 +10,10 @@ PREFERRED_PROVIDER_acrn-hypervisor ?= "acrn-hypervisor"
 PREFERRED_PROVIDER_acrn-devicemodel ?= "acrn-devicemodel"
 PREFERRED_PROVIDER_acrn-tools ?= "acrn-tools"
 
+PREFERRED_PROVIDER_libvirt = "acrn-libvirt"
+PREFERRED_PROVIDER_libvirt-native = "acrn-libvirt-native"
+PREFERRED_PROVIDER_nativesdk-libvirt = "nativesdk-acrn-libvirt"
+
 # ACRN hypervisor log setting, sensible defaults
 HVLOG_PARAM = "hvlog=2M@0xE00000 ${@bb.utils.contains('EFI_PROVIDER','grub-efi','memmap=2M\$0xE00000','memmap=2M$0xE00000',d)} "
 LINUX_ACRN_APPEND ?= "${@bb.utils.contains('PREFERRED_PROVIDER_acrn-hypervisor','acrn-hypervisor','hvlog=2M@0x1FE00000 ','${HVLOG_PARAM}',d)}"

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -12,3 +12,8 @@ LICENSE_PATH += "${LAYERDIR}/custom-licenses"
 
 LAYERDEPENDS_meta-acrn = "core intel"
 LAYERSERIES_COMPAT_meta-acrn = "zeus dunfell"
+
+BBFILES_DYNAMIC += " \
+    virtualization-layer:${LAYERDIR}/dynamic-layers/virtualization-layer/*/*/*.bb \
+    virtualization-layer:${LAYERDIR}/dynamic-layers/virtualization-layer/*/*/*.bbappend \
+"

--- a/dynamic-layers/virtualization-layer/recipes-extended/libvirt/README
+++ b/dynamic-layers/virtualization-layer/recipes-extended/libvirt/README
@@ -1,0 +1,26 @@
+libvirt default connection mode between client(where for example virsh runs) and
+server(where libvirtd runs) is tls which requires keys and certificates for
+certificate authority, client and server to be properly generated and deployed.
+Otherwise, servers and clients cannot be connected.
+
+recipes-extended/libvirt/libvirt/gnutls-help.py is provided to help generate
+required keys and certificates.
+
+Usage:
+gnutls-help.py [-a|--ca-info] <ca.info> [-b|--server-info] <server.info> [-c|--client-info] <client.info>
+If ca.info or server.info or client.info is not provided, a corresponding sample file will be generated.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!! "ip_address" field of server.info must be IP address of the server. !!
+!! For more details, please refer to:                                  !!
+!! https://libvirt.org/remote.html#Remote_certificates                 !!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+Please deploy cacert.pem     to CA and server and client /etc/pki/CA/cacert.pem
+Please deploy serverkey.pem  to server /etc/pki/libvirt/private/serverkey.pem
+Please deploy servercert.pem to server /etc/pki/libvirt/servercert.pem
+Please deploy clientkey.pem  to client /etc/pki/libvirt/private/clientkey.pem
+Please deploy clientcert.pem to client /etc/pki/libvirt/clientcert.pem"
+
+For more details please refer to libvirt official document,
+https://libvirt.org/remote.html#Remote_certificates

--- a/dynamic-layers/virtualization-layer/recipes-extended/libvirt/acrn-libvirt/0001-build-drop-unnecessary-libgnu.la-reference.patch
+++ b/dynamic-layers/virtualization-layer/recipes-extended/libvirt/acrn-libvirt/0001-build-drop-unnecessary-libgnu.la-reference.patch
@@ -1,0 +1,33 @@
+From 4945576d6c5c7cc9a21a58aaa312829567af13db Mon Sep 17 00:00:00 2001
+From: Bruce Ashfield <bruce.ashfield@gmail.com>
+Date: Sat, 7 Mar 2020 21:36:27 -0500
+Subject: [PATCH] build: drop unnecessary libgnu.la reference
+
+Signed-off-by: Bruce Ashfield <bruce.ashfield@gmail.com>
+---
+ tools/Makefile.am | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/tools/Makefile.am b/tools/Makefile.am
+index 2a0a989..93fe283 100644
+--- a/tools/Makefile.am
++++ b/tools/Makefile.am
+@@ -168,7 +168,6 @@ virt_host_validate_LDADD = \
+ 
+ if WITH_GNUTLS
+ virt_host_validate_LDADD += ../src/libvirt-net-rpc.la \
+-                            ../gnulib/lib/libgnu.la   \
+                             $(NULL)
+ endif
+ 
+@@ -270,7 +269,6 @@ BUILT_SOURCES =
+ 
+ if WITH_GNUTLS
+ virsh_LDADD += ../src/libvirt-net-rpc.la \
+-               ../gnulib/lib/libgnu.la   \
+                $(NULL)
+ endif
+ 
+-- 
+2.19.1
+

--- a/dynamic-layers/virtualization-layer/recipes-extended/libvirt/acrn-libvirt/0001-ptest-Remove-Windows-1252-check-from-esxutilstest.patch
+++ b/dynamic-layers/virtualization-layer/recipes-extended/libvirt/acrn-libvirt/0001-ptest-Remove-Windows-1252-check-from-esxutilstest.patch
@@ -1,0 +1,26 @@
+From 1601c21b653bf2bea2547e5efcf1f3cbb8b73f65 Mon Sep 17 00:00:00 2001
+From: He Zhe <zhe.he@windriver.com>
+Date: Tue, 23 Aug 2016 02:28:47 -0400
+Subject: [PATCH] ptest: Remove Windows-1252 check from esxutilstest
+
+Currently we use iconv from glibc-locale and it does not support
+Windows-1252 and we don't need support windows character encoding.
+
+Signed-off-by: He Zhe <zhe.he@windriver.com>
+
+---
+ tests/esxutilstest.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/tests/esxutilstest.c b/tests/esxutilstest.c
+index 2e20200..6c57889 100644
+--- a/tests/esxutilstest.c
++++ b/tests/esxutilstest.c
+@@ -256,7 +256,6 @@ mymain(void)
+     DO_TEST(ParseDatastorePath);
+     DO_TEST(ConvertDateTimeToCalendarTime);
+     DO_TEST(EscapeDatastoreItem);
+-    DO_TEST(ConvertWindows1252ToUTF8);
+ 
+     return result == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+ }

--- a/dynamic-layers/virtualization-layer/recipes-extended/libvirt/acrn-libvirt/configure.ac-search-for-rpc-rpc.h-in-the-sysroot.patch
+++ b/dynamic-layers/virtualization-layer/recipes-extended/libvirt/acrn-libvirt/configure.ac-search-for-rpc-rpc.h-in-the-sysroot.patch
@@ -1,0 +1,34 @@
+From d074f34dd0fc671ab05367eda9cc7a965708fbed Mon Sep 17 00:00:00 2001
+From: Mark Asselstine <mark.asselstine@windriver.com>
+Date: Thu, 10 May 2018 12:05:04 -0400
+Subject: [PATCH] configure.ac: search for rpc/rpc.h in the sysroot
+
+We want to avoid host contamination and use the sysroot as the base
+directory for our search so add the '=' the the '-I' when searching
+for libtirpc's rpc.h header.
+
+Upstream-Status: Inappropriate [old release]
+
+Signed-off-by: Mark Asselstine <mark.asselstine@windriver.com>
+
+---
+ m4/virt-xdr.m4 | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/m4/virt-xdr.m4 b/m4/virt-xdr.m4
+index 8375415..12b51f7 100644
+--- a/m4/virt-xdr.m4
++++ b/m4/virt-xdr.m4
+@@ -30,10 +30,10 @@ AC_DEFUN([LIBVIRT_CHECK_XDR], [
+     ])
+     with_xdr="yes"
+ 
+-    dnl Recent glibc requires -I/usr/include/tirpc for <rpc/rpc.h>
++    dnl Recent glibc requires -I=/usr/include/tirpc for <rpc/rpc.h>
+     old_CFLAGS=$CFLAGS
+     AC_CACHE_CHECK([where to find <rpc/rpc.h>], [lv_cv_xdr_cflags], [
+-      for add_CFLAGS in '' '-I/usr/include/tirpc' 'missing'; do
++      for add_CFLAGS in '' '-I=/usr/include/tirpc' 'missing'; do
+         if test x"$add_CFLAGS" = xmissing; then
+           lv_cv_xdr_cflags=missing; break
+         fi

--- a/dynamic-layers/virtualization-layer/recipes-extended/libvirt/acrn-libvirt/dnsmasq.conf
+++ b/dynamic-layers/virtualization-layer/recipes-extended/libvirt/acrn-libvirt/dnsmasq.conf
@@ -1,0 +1,2 @@
+bind-interfaces
+except-interface=virbr0

--- a/dynamic-layers/virtualization-layer/recipes-extended/libvirt/acrn-libvirt/gnutls-helper.py
+++ b/dynamic-layers/virtualization-layer/recipes-extended/libvirt/acrn-libvirt/gnutls-helper.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2019 Wind River Systems, Inc.
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+import os, sys, getopt
+
+banner = \
+'''\
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!! "ip_address" field of server.info must be IP address of the server. !!
+!! For more details, please refer to:                                  !!
+!! https://libvirt.org/remote.html#Remote_certificates                 !!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+Please deploy cacert.pem     to CA and server and client /etc/pki/CA/cacert.pem
+Please deploy serverkey.pem  to server /etc/pki/libvirt/private/serverkey.pem
+Please deploy servercert.pem to server /etc/pki/libvirt/servercert.pem
+Please deploy clientkey.pem  to client /etc/pki/libvirt/private/clientkey.pem
+Please deploy clientcert.pem to client /etc/pki/libvirt/clientcert.pem"
+'''
+
+if os.system('which certtool > /dev/null 2>&1') != 0:
+    print('certtool is not available. It is provided by \n\
+gnutls-bin on Yocto like Linux or \n\
+gnutls-bin on Debian like distribution or \n\
+gnutls-utils on Redhat like distribution.')
+    sys.exit()
+
+cainfo = ""
+serverinfo = ""
+clientinfo = ""
+yes = 0
+
+try:
+    opts, args = getopt.getopt(sys.argv[1:], "ha:b:c:y", ["help", "ca-info=", "server-info=", "client-info=", "yes"])
+except getopt.GetoptError:
+    print('Usage:\n{} [-a|--ca-info] <ca.info> [-b|--server-info] <server.info> [-c|--client-info] <client.info> [-y|--yes]'.format(sys.argv[0]))
+    print('If ca.info or server.info or client.info is not provided, a corresponding sample file will be generated.')
+    sys.exit(2)
+for opt, arg in opts:
+    if opt in ("-h", "--help"):
+        print('Usage:\n{} [-a|--ca-info] <ca.info> [-b|--server-info] <server.info> [-c|--client-info] <client.info> [-y|--yes]'.format(sys.argv[0]))
+        print('If ca.info or server.info or client.info is not provided, a corresponding sample file will be generated.\n')
+        print(banner)
+        sys.exit()
+    elif opt in ("-a", "--ca-info"):
+        cainfo = arg
+    elif opt in ("-b", "--server-info"):
+        serverinfo = arg
+    elif opt in ("-c", "--client-info"):
+        clientinfo = arg
+    elif opt in ("-y", "--yes"):
+        yes = 1
+
+cainfodefault = \
+'''cn = CA
+ca
+cert_signing_key
+'''
+
+serverinfodefault = \
+'''organization = Organization
+cn = Server
+dns_name = DNS Name
+ip_address = 127.0.0.1
+tls_www_server
+encryption_key
+signing_key
+'''
+
+clientinfodefault = \
+'''country = Country
+state = State
+locality = Locality
+organization = Organization
+cn = Client
+tls_www_client
+encryption_key
+signing_key
+'''
+
+if not cainfo:
+    if yes == 0:
+        opt = input('{}\nca.info not provided by -a, the above will be used [y/n]?'.format(cainfodefault))
+        if opt != 'y':
+            exit()
+    cainfo = "ca.info"
+    with open(cainfo, mode='w') as f:
+        f.write(cainfodefault)
+
+if not serverinfo:
+    if yes == 0:
+        opt = input('{}\nserver.info not provided by -b, the above will be used [y/n]?'.format(serverinfodefault))
+        if opt != 'y':
+            exit()
+    serverinfo = "server.info"
+    with open(serverinfo, mode='w') as f:
+        f.write(serverinfodefault)
+
+if not clientinfo:
+    if yes == 0:
+        opt = input('{}\nclient.info not provided by -c, the above will be used [y/n]?'.format(clientinfodefault))
+        if opt != 'y':
+            sys.exit()
+    clientinfo = "client.info"
+    with open(clientinfo, mode='w') as f:
+        f.write(clientinfodefault)
+
+if os.system("certtool --generate-privkey > cakey.pem") != 0:
+    print('ca private key failed.')
+    sys.exit()
+
+if os.system("certtool --generate-self-signed --load-privkey cakey.pem --template {} --outfile cacert.pem".format(cainfo)) != 0:
+    print('ca cert failed.')
+    sys.exit()
+
+if os.system("certtool --generate-privkey > serverkey.pem") != 0:
+    print('server private key failed.')
+    sys.exit()
+
+if os.system("certtool --generate-certificate --load-privkey serverkey.pem --load-ca-certificate cacert.pem --load-ca-privkey cakey.pem --template {} --outfile servercert.pem".format(serverinfo)) != 0:
+    print('server cert failed.')
+    sys.exit()
+
+if os.system("certtool --generate-privkey > clientkey.pem") != 0:
+    print('client private key failed.')
+    sys.exit()
+
+if os.system("certtool --generate-certificate --load-privkey clientkey.pem --load-ca-certificate cacert.pem --load-ca-privkey cakey.pem --template {} --outfile clientcert.pem".format(clientinfo)) != 0:
+    print('client cert failed.')
+    sys.exit()
+
+print(banner)

--- a/dynamic-layers/virtualization-layer/recipes-extended/libvirt/acrn-libvirt/hook_support.py
+++ b/dynamic-layers/virtualization-layer/recipes-extended/libvirt/acrn-libvirt/hook_support.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2014 Wind River Systems, Inc. 
+# 
+# Description: Calls other scripts in order, so that there can be multiple
+# scripts for a particular hook tied to libvirt.
+#
+# For example: If this script is called "qemu" and is in the
+# "/etc/libvirt/hooks/" directory.  This script will be called by libvirt
+# when certain actions are performed on a qemu guest.  This script then
+# will in turn call any executable file in the same directory matching
+# "qemu-" followed by at least one alpha-numeric character.  The scripts
+# are called in order (based on the python sorted function), and once any
+# sub-script returns a non-zero exit code no futher scripts are called.
+# This script passes any arguments it retrieves on the command line and a
+# copy of stdin to the sub-scripts it calls.
+
+import os
+import re
+import subprocess
+import sys
+
+def main():
+	return_value = 0
+	hook_name = os.path.basename( __file__ )
+	try:
+		hook_dir = os.path.dirname( __file__ )
+		hook_args = sys.argv
+		del hook_args[ 0 ] # Remove executable from argument list
+
+		# Save stdin, so we can pass it to each sub-script.
+		if sys.stdin.isatty():
+			stdin_save = [ "" ]
+		else: 
+			stdin_save = sys.stdin.readlines()
+		# Match the name name of the hook + a dash + atleast
+		# one alpha-numeric character.
+		matcher = re.compile( "%s-\w+" % hook_name )
+		for file_name in sorted( os.listdir( hook_dir ) ):
+			file_path = os.path.join( hook_dir, file_name )
+			if matcher.match( file_name ) \
+			   and os.access( file_path, os.X_OK ) \
+			   and os.path.isfile( file_path ) \
+			   and return_value == 0:
+				cmd = [ file_path ] + hook_args
+				p = subprocess.Popen( cmd, stdin=subprocess.PIPE )
+				p.communicate( input = ''.join( stdin_save ) )[0]
+				return_value = p.wait()
+	except Exception as e:
+		sys.stderr.write( "%s hook error: %s\n" % ( hook_name, str( e ) ) )
+		return_value = 1
+	return return_value
+
+if __name__ == '__main__':
+	sys.exit( main() )

--- a/dynamic-layers/virtualization-layer/recipes-extended/libvirt/acrn-libvirt/install-missing-file.patch
+++ b/dynamic-layers/virtualization-layer/recipes-extended/libvirt/acrn-libvirt/install-missing-file.patch
@@ -1,0 +1,50 @@
+From 75c974d28133ff85d299b7a53427653c47513a45 Mon Sep 17 00:00:00 2001
+From: Dengke Du <dengke.du@windriver.com>
+Date: Wed, 8 May 2019 17:24:17 +0800
+Subject: [PATCH] Install missing conf file
+
+openvzutilstest.conf file is needed by openvzutilstest test.
+
+Upstream-Status: Inapproriate
+
+Signed-off-by: Catalin Enache <catalin.enache@windriver.com>
+[KK: Update context for 1.3.5.]
+Signed-off-by: Kai Kang <kai.kang@windriver.com>
+[MA: Update context for v4.3.0]
+Signed-off-by: Mark Asselstine <mark.asselstine@windriver.com>
+[DDU: Update context for v5.3.0]
+Signed-off-by: Dengke Du <dengke.du@windriver.com>
+
+---
+ tests/Makefile.am | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/tests/Makefile.am b/tests/Makefile.am
+index 7a0aee3..380637d 100644
+--- a/tests/Makefile.am
++++ b/tests/Makefile.am
+@@ -172,6 +172,7 @@ EXTRA_DIST = \
+ 	$(NULL)
+ 
+ test_helpers = commandhelper ssh
++test_misc =
+ test_programs = virshtest sockettest \
+ 	virhostcputest virbuftest \
+ 	commandtest seclabeltest \
+@@ -310,6 +311,7 @@ endif WITH_LXC
+ 
+ if WITH_OPENVZ
+ test_programs += openvzutilstest
++test_misc += openvzutilstest.conf
+ endif WITH_OPENVZ
+ 
+ if WITH_ESX
+@@ -1553,7 +1555,7 @@ endif  ! WITH_LINUX
+ 
+ buildtest-TESTS: $(TESTS) $(test_libraries) $(test_helpers)
+ 
+-PTESTS = $(TESTS) $(test_helpers) test-lib.sh virschematest
++PTESTS = $(TESTS) $(test_helpers) $(test_misc) test-lib.sh virschematest
+ 
+ install-ptest:
+ 	list='$(TESTS) $(test_helpers) test-lib.sh virschematest'

--- a/dynamic-layers/virtualization-layer/recipes-extended/libvirt/acrn-libvirt/libvirt-1.0.3-fix-thread-safety-in-lxc-callback-handling.patch
+++ b/dynamic-layers/virtualization-layer/recipes-extended/libvirt/acrn-libvirt/libvirt-1.0.3-fix-thread-safety-in-lxc-callback-handling.patch
@@ -1,0 +1,63 @@
+From ad5d9cee87357f9f38f62583119606ef95ba10df Mon Sep 17 00:00:00 2001
+From: Bogdan Purcareata <bogdan.purcareata@freescale.com>
+Date: Fri, 24 May 2013 16:46:00 +0300
+Subject: [PATCH] Fix thread safety in LXC callback handling
+
+Signed-off-by: Bogdan Purcareata <bogdan.purcareata@freescale.com>
+---
+ src/lxc/lxc_process.c | 18 +++++++++++++++++-
+ 1 file changed, 17 insertions(+), 1 deletion(-)
+
+diff --git a/src/lxc/lxc_process.c b/src/lxc/lxc_process.c
+index aaa81a7..0eadc67 100644
+--- a/src/lxc/lxc_process.c
++++ b/src/lxc/lxc_process.c
+@@ -609,8 +609,13 @@ static void virLXCProcessMonitorExitNotify(virLXCMonitorPtr mon ATTRIBUTE_UNUSED
+                                            virLXCProtocolExitStatus status,
+                                            virDomainObjPtr vm)
+ {
++    virLXCDriverPtr driver = lxc_driver;
+     virLXCDomainObjPrivatePtr priv = vm->privateData;
+ 
++    lxcDriverLock(driver);
++    virObjectLock(vm);
++    lxcDriverUnlock(driver);
++
+     switch (status) {
+     case VIR_LXC_PROTOCOL_EXIT_STATUS_SHUTDOWN:
+         priv->stopReason = VIR_DOMAIN_EVENT_STOPPED_SHUTDOWN;
+@@ -628,6 +633,8 @@ static void virLXCProcessMonitorExitNotify(virLXCMonitorPtr mon ATTRIBUTE_UNUSED
+     }
+     VIR_DEBUG("Domain shutoff reason %d (from status %d)",
+               priv->stopReason, status);
++
++    virObjectUnlock(vm);
+ }
+ 
+ /* XXX a little evil */
+@@ -636,12 +643,21 @@ static void virLXCProcessMonitorInitNotify(virLXCMonitorPtr mon ATTRIBUTE_UNUSED
+                                            pid_t initpid,
+                                            virDomainObjPtr vm)
+ {
+-    virLXCDomainObjPrivatePtr priv = vm->privateData;
++    virLXCDriverPtr driver = lxc_driver;
++    virLXCDomainObjPrivatePtr priv;
++
++    lxcDriverLock(driver);
++    virObjectLock(vm);
++    lxcDriverUnlock(driver);
++
++    priv = vm->privateData;
+     priv->initpid = initpid;
+     virDomainAuditInit(vm, initpid);
+ 
+     if (virDomainSaveStatus(lxc_driver->caps, lxc_driver->stateDir, vm) < 0)
+         VIR_WARN("Cannot update XML with PID for LXC %s", vm->def->name);
++
++    virObjectUnlock(vm);
+ }
+ 
+ static virLXCMonitorCallbacks monitorCallbacks = {
+-- 
+1.7.11.7
+

--- a/dynamic-layers/virtualization-layer/recipes-extended/libvirt/acrn-libvirt/libvirt-use-pkg-config-to-locate-libcap.patch
+++ b/dynamic-layers/virtualization-layer/recipes-extended/libvirt/acrn-libvirt/libvirt-use-pkg-config-to-locate-libcap.patch
@@ -1,0 +1,43 @@
+From 57b645c6db405bf2e22f4589ea5560a14975058f Mon Sep 17 00:00:00 2001
+From: Bruce Ashfield <bruce.ashfield@windriver.com>
+Date: Wed, 8 Apr 2015 13:03:03 -0400
+Subject: [PATCH] libvirt: use pkg-config to locate libcap
+
+libvirt wants to use pcap-config to locate the exisence and location
+of libpcap. oe-core stubs this script and replaces it with pkg-config,
+which can lead to the host pcap-config triggering and either breaking
+the build or introducing host contamination.
+
+To fix this issue, we patch configure to use 'pkg-config libcap' to
+locate the correct libraries.
+
+Signed-off-by: Bruce Ashfield <bruce.ashfield@windriver.com>
+[MA: Update to apply agains v4.3.0]
+Signed-off-by: Mark Asselstine <mark.asselstine@windriver.com>
+
+---
+ m4/virt-libpcap.m4 | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/m4/virt-libpcap.m4 b/m4/virt-libpcap.m4
+index 605c2fd..e0ab018 100644
+--- a/m4/virt-libpcap.m4
++++ b/m4/virt-libpcap.m4
+@@ -23,14 +23,14 @@ AC_DEFUN([LIBVIRT_ARG_LIBPCAP], [
+ 
+ AC_DEFUN([LIBVIRT_CHECK_LIBPCAP], [
+   LIBPCAP_REQUIRED="1.5.0"
+-  LIBPCAP_CONFIG="pcap-config"
++  LIBPCAP_CONFIG="pkg-config libpcap"
+   LIBPCAP_CFLAGS=""
+   LIBPCAP_LIBS=""
+ 
+   if test "x$with_libpcap" != "xno"; then
+     case $with_libpcap in
+-      ''|yes|check) LIBPCAP_CONFIG="pcap-config" ;;
+-      *)      LIBPCAP_CONFIG="$with_libpcap/bin/pcap-config" ;;
++      ''|yes|check) LIBPCAP_CONFIG="pkg-config libpcap" ;;
++      *)      LIBPCAP_CONFIG="$with_libpcap/bin/pkg-config libpcap" ;;
+     esac
+     AS_IF([test "x$LIBPCAP_CONFIG" != "x"], [
+       AC_MSG_CHECKING(libpcap $LIBPCAP_CONFIG >= $LIBPCAP_REQUIRED )

--- a/dynamic-layers/virtualization-layer/recipes-extended/libvirt/acrn-libvirt/libvirtd.conf
+++ b/dynamic-layers/virtualization-layer/recipes-extended/libvirt/acrn-libvirt/libvirtd.conf
@@ -1,0 +1,393 @@
+# Master libvirt daemon configuration file
+#
+# For further information consult http://libvirt.org/format.html
+#
+# NOTE: the tests/daemon-conf regression test script requires
+# that each "PARAMETER = VALUE" line in this file have the parameter
+# name just after a leading "#".
+
+#################################################################
+#
+# Network connectivity controls
+#
+
+# Flag listening for secure TLS connections on the public TCP/IP port.
+# NB, must pass the --listen flag to the libvirtd process for this to
+# have any effect.
+#
+# It is necessary to setup a CA and issue server certificates before
+# using this capability.
+#
+# This is enabled by default, uncomment this to disable it
+listen_tls = 0
+
+# Listen for unencrypted TCP connections on the public TCP/IP port.
+# NB, must pass the --listen flag to the libvirtd process for this to
+# have any effect.
+#
+# Using the TCP socket requires SASL authentication by default. Only
+# SASL mechanisms which support data encryption are allowed. This is
+# DIGEST_MD5 and GSSAPI (Kerberos5)
+#
+# This is disabled by default, uncomment this to enable it.
+listen_tcp = 1
+
+
+
+# Override the port for accepting secure TLS connections
+# This can be a port number, or service name
+#
+#tls_port = "16514"
+
+# Override the port for accepting insecure TCP connections
+# This can be a port number, or service name
+#
+#tcp_port = "16509"
+
+
+# Override the default configuration which binds to all network
+# interfaces. This can be a numeric IPv4/6 address, or hostname
+#
+#listen_addr = "192.168.0.1"
+
+
+# Flag toggling mDNS advertizement of the libvirt service.
+#
+# Alternatively can disable for all services on a host by
+# stopping the Avahi daemon
+#
+# This is enabled by default, uncomment this to disable it
+#mdns_adv = 0
+
+# Override the default mDNS advertizement name. This must be
+# unique on the immediate broadcast network.
+#
+# The default is "Virtualization Host HOSTNAME", where HOSTNAME
+# is subsituted for the short hostname of the machine (without domain)
+#
+#mdns_name = "Virtualization Host Joe Demo"
+
+
+#################################################################
+#
+# UNIX socket access controls
+#
+
+# Set the UNIX domain socket group ownership. This can be used to
+# allow a 'trusted' set of users access to management capabilities
+# without becoming root.
+#
+# This is restricted to 'root' by default.
+#unix_sock_group = "libvirt"
+
+# Set the UNIX socket permissions for the R/O socket. This is used
+# for monitoring VM status only
+#
+# Default allows any user. If setting group ownership may want to
+# restrict this to:
+#unix_sock_ro_perms = "0777"
+
+# Set the UNIX socket permissions for the R/W socket. This is used
+# for full management of VMs
+#
+# Default allows only root. If PolicyKit is enabled on the socket,
+# the default will change to allow everyone (eg, 0777)
+#
+# If not using PolicyKit and setting group ownership for access
+# control then you may want to relax this to:
+#unix_sock_rw_perms = "0770"
+
+# Set the name of the directory in which sockets will be found/created.
+#unix_sock_dir = "/var/run/libvirt"
+
+#################################################################
+#
+# Authentication.
+#
+#  - none: do not perform auth checks. If you can connect to the
+#          socket you are allowed. This is suitable if there are
+#          restrictions on connecting to the socket (eg, UNIX
+#          socket permissions), or if there is a lower layer in
+#          the network providing auth (eg, TLS/x509 certificates)
+#
+#  - sasl: use SASL infrastructure. The actual auth scheme is then
+#          controlled from /etc/sasl2/libvirt.conf. For the TCP
+#          socket only GSSAPI & DIGEST-MD5 mechanisms will be used.
+#          For non-TCP or TLS sockets,  any scheme is allowed.
+#
+#  - polkit: use PolicyKit to authenticate. This is only suitable
+#            for use on the UNIX sockets. The default policy will
+#            require a user to supply their own password to gain
+#            full read/write access (aka sudo like), while anyone
+#            is allowed read/only access.
+#
+# Set an authentication scheme for UNIX read-only sockets
+# By default socket permissions allow anyone to connect
+#
+# To restrict monitoring of domains you may wish to enable
+# an authentication mechanism here
+#auth_unix_ro = "none"
+
+# Set an authentication scheme for UNIX read-write sockets
+# By default socket permissions only allow root. If PolicyKit
+# support was compiled into libvirt, the default will be to
+# use 'polkit' auth.
+#
+# If the unix_sock_rw_perms are changed you may wish to enable
+# an authentication mechanism here
+#auth_unix_rw = "none"
+
+# Change the authentication scheme for TCP sockets.
+#
+# If you don't enable SASL, then all TCP traffic is cleartext.
+# Don't do this outside of a dev/test scenario. For real world
+# use, always enable SASL and use the GSSAPI or DIGEST-MD5
+# mechanism in /etc/sasl2/libvirt.conf
+#auth_tcp = "sasl"
+
+# Change the authentication scheme for TLS sockets.
+#
+# TLS sockets already have encryption provided by the TLS
+# layer, and limited authentication is done by certificates
+#
+# It is possible to make use of any SASL authentication
+# mechanism as well, by using 'sasl' for this option
+#auth_tls = "none"
+
+
+
+#################################################################
+#
+# TLS x509 certificate configuration
+#
+
+
+# Override the default server key file path
+#
+#key_file = "/etc/pki/libvirt/private/serverkey.pem"
+
+# Override the default server certificate file path
+#
+#cert_file = "/etc/pki/libvirt/servercert.pem"
+
+# Override the default CA certificate path
+#
+#ca_file = "/etc/pki/CA/cacert.pem"
+
+# Specify a certificate revocation list.
+#
+# Defaults to not using a CRL, uncomment to enable it
+#crl_file = "/etc/pki/CA/crl.pem"
+
+
+
+#################################################################
+#
+# Authorization controls
+#
+
+
+# Flag to disable verification of our own server certificates
+#
+# When libvirtd starts it performs some sanity checks against
+# its own certificates.
+#
+# Default is to always run sanity checks. Uncommenting this
+# will disable sanity checks which is not a good idea
+#tls_no_sanity_certificate = 1
+
+# Flag to disable verification of client certificates
+#
+# Client certificate verification is the primary authentication mechanism.
+# Any client which does not present a certificate signed by the CA
+# will be rejected.
+#
+# Default is to always verify. Uncommenting this will disable
+# verification - make sure an IP whitelist is set
+#tls_no_verify_certificate = 1
+
+
+# A whitelist of allowed x509  Distinguished Names
+# This list may contain wildcards such as
+#
+#    "C=GB,ST=London,L=London,O=Red Hat,CN=*"
+#
+# See the POSIX fnmatch function for the format of the wildcards.
+#
+# NB If this is an empty list, no client can connect, so comment out
+# entirely rather than using empty list to disable these checks
+#
+# By default, no DN's are checked
+#tls_allowed_dn_list = ["DN1", "DN2"]
+
+
+# A whitelist of allowed SASL usernames. The format for usernames
+# depends on the SASL authentication mechanism. Kerberos usernames
+# look like username@REALM
+#
+# This list may contain wildcards such as
+#
+#    "*@EXAMPLE.COM"
+#
+# See the POSIX fnmatch function for the format of the wildcards.
+#
+# NB If this is an empty list, no client can connect, so comment out
+# entirely rather than using empty list to disable these checks
+#
+# By default, no Username's are checked
+#sasl_allowed_username_list = ["joe@EXAMPLE.COM", "fred@EXAMPLE.COM" ]
+
+
+
+#################################################################
+#
+# Processing controls
+#
+
+# The maximum number of concurrent client connections to allow
+# over all sockets combined.
+#max_clients = 20
+
+
+# The minimum limit sets the number of workers to start up
+# initially. If the number of active clients exceeds this,
+# then more threads are spawned, upto max_workers limit.
+# Typically you'd want max_workers to equal maximum number
+# of clients allowed
+#min_workers = 5
+#max_workers = 20
+
+
+# The number of priority workers. If all workers from above
+# pool will stuck, some calls marked as high priority
+# (notably domainDestroy) can be executed in this pool.
+#prio_workers = 5
+
+# Total global limit on concurrent RPC calls. Should be
+# at least as large as max_workers. Beyond this, RPC requests
+# will be read into memory and queued. This directly impact
+# memory usage, currently each request requires 256 KB of
+# memory. So by default upto 5 MB of memory is used
+#
+# XXX this isn't actually enforced yet, only the per-client
+# limit is used so far
+#max_requests = 20
+
+# Limit on concurrent requests from a single client
+# connection. To avoid one client monopolizing the server
+# this should be a small fraction of the global max_requests
+# and max_workers parameter
+#max_client_requests = 5
+
+#################################################################
+#
+# Logging controls
+#
+
+# Logging level: 4 errors, 3 warnings, 2 information, 1 debug
+# basically 1 will log everything possible
+#log_level = 3
+
+# Logging filters:
+# A filter allows to select a different logging level for a given category
+# of logs
+# The format for a filter is:
+#    x:name
+#      where name is a match string e.g. remote or qemu
+# the x prefix is the minimal level where matching messages should be logged
+#    1: DEBUG
+#    2: INFO
+#    3: WARNING
+#    4: ERROR
+#
+# Multiple filter can be defined in a single @filters, they just need to be
+# separated by spaces.
+#
+# e.g:
+# log_filters="3:remote 4:event"
+# to only get warning or errors from the remote layer and only errors from
+# the event layer.
+
+# Logging outputs:
+# An output is one of the places to save logging information
+# The format for an output can be:
+#    x:stderr
+#      output goes to stderr
+#    x:syslog:name
+#      use syslog for the output and use the given name as the ident
+#    x:file:file_path
+#      output to a file, with the given filepath
+# In all case the x prefix is the minimal level, acting as a filter
+#    1: DEBUG
+#    2: INFO
+#    3: WARNING
+#    4: ERROR
+#
+# Multiple output can be defined, they just need to be separated by spaces.
+# e.g.:
+# log_outputs="3:syslog:libvirtd"
+# to log all warnings and errors to syslog under the libvirtd ident
+
+# Log debug buffer size: default 64
+# The daemon keeps an internal debug log buffer which will be dumped in case
+# of crash or upon receiving a SIGUSR2 signal. This setting allows to override
+# the default buffer size in kilobytes.
+# If value is 0 or less the debug log buffer is deactivated
+#log_buffer_size = 64
+
+
+##################################################################
+#
+# Auditing
+#
+# This setting allows usage of the auditing subsystem to be altered:
+#
+#   audit_level == 0  -> disable all auditing
+#   audit_level == 1  -> enable auditing, only if enabled on host (default)
+#   audit_level == 2  -> enable auditing, and exit if disabled on host
+#
+#audit_level = 2
+#
+# If set to 1, then audit messages will also be sent
+# via libvirt logging infrastructure. Defaults to 0
+#
+#audit_logging = 1
+
+###################################################################
+# UUID of the host:
+# Provide the UUID of the host here in case the command
+# 'dmidecode -s system-uuid' does not provide a valid uuid. In case
+# 'dmidecode' does not provide a valid UUID and none is provided here, a
+# temporary UUID will be generated.
+# Keep the format of the example UUID below. UUID must not have all digits
+# be the same.
+
+# NB This default all-zeros UUID will not work. Replace
+# it with the output of the 'uuidgen' command and then
+# uncomment this entry
+#host_uuid = "00000000-0000-0000-0000-000000000000"
+
+###################################################################
+# Keepalive protocol:
+# This allows libvirtd to detect broken client connections or even
+# dead client.  A keepalive message is sent to a client after
+# keepalive_interval seconds of inactivity to check if the client is
+# still responding; keepalive_count is a maximum number of keepalive
+# messages that are allowed to be sent to the client without getting
+# any response before the connection is considered broken.  In other
+# words, the connection is automatically closed approximately after
+# keepalive_interval * (keepalive_count + 1) seconds since the last
+# message received from the client.  If keepalive_interval is set to
+# -1, libvirtd will never send keepalive requests; however clients
+# can still send them and the deamon will send responses.  When
+# keepalive_count is set to 0, connections will be automatically
+# closed after keepalive_interval seconds of inactivity without
+# sending any keepalive messages.
+#
+#keepalive_interval = 5
+#keepalive_count = 5
+#
+# If set to 1, libvirtd will refuse to talk to clients that do not
+# support keepalive protocol.  Defaults to 0.
+#
+#keepalive_required = 1

--- a/dynamic-layers/virtualization-layer/recipes-extended/libvirt/acrn-libvirt/libvirtd.sh
+++ b/dynamic-layers/virtualization-layer/recipes-extended/libvirt/acrn-libvirt/libvirtd.sh
@@ -1,0 +1,103 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides: libvirtd
+# Required-Start: $local_fs $network dbus
+# Required-Stop: $local_fs $network dbus
+# Default-Start: 2 3 4 5
+# Default-Stop: 0 1 6
+### END INIT INFO
+
+if [ -f /lib/lsb/init-functions ]
+then
+    . /lib/lsb/init-functions
+else
+    # int log_begin_message (char *message)
+    log_begin_msg () {
+        if [ -z "$1" ]; then
+	    return 1
+        fi
+        echo " * $@"
+    }
+
+    # int log_end_message (int exitstatus)
+    log_end_msg () {
+	
+    # If no arguments were passed, return
+	[ -z "$1" ] && return 1
+	
+    # Only do the fancy stuff if we have an appropriate terminal
+    # and if /usr is already mounted
+	TPUT=/usr/bin/tput
+	EXPR=/usr/bin/expr
+	if [ -x $TPUT ] && [ -x $EXPR ] && $TPUT hpa 60 >/dev/null 2>&1; then
+	    COLS=`$TPUT cols`
+	    if [ -n "$COLS" ]; then
+		COL=`$EXPR $COLS - 7`
+	    else
+		COL=73
+	    fi
+	    UP=`$TPUT cuu1`
+	    END=`$TPUT hpa $COL`
+	    START=`$TPUT hpa 0`
+	    RED=`$TPUT setaf 1`
+	    NORMAL=`$TPUT op`
+	    if [ $1 -eq 0 ]; then
+		echo "$UP$END[ ok ]"
+	    else
+		echo -e "$UP$START $RED*$NORMAL$END[${RED}fail${NORMAL}]"
+	    fi
+	else
+	    if [ $1 -eq 0 ]; then
+		echo "   ...done."
+	    else
+		echo "   ...fail!"
+	    fi
+	fi
+	return $1
+    }
+    
+    log_warning_msg () {
+	if log_use_fancy_output; then
+	    YELLOW=`$TPUT setaf 3`
+	    NORMAL=`$TPUT op`
+	    echo "$YELLOW*$NORMAL $@"
+	else
+	    echo "$@"
+	fi
+    }
+
+fi
+
+case "$1" in
+        start)
+                if [ -e /var/run/libvirtd.pid ]; then
+                        if [ -d /proc/$(cat /var/run/libvirtd.pid) ]; then
+                                echo "virtualization library already started; not starting."
+                        else
+                                echo "Removing stale PID file /var/run/libvirtd.pid."
+                                rm -f /var/run/libvirtd.pid
+                        fi
+                fi
+                log_begin_msg "Starting virtualization library daemon: libvirtd"
+                if [ ! -e /var/run/libvirtd.pid ]; then
+                    start-stop-daemon -K -x /usr/bin/dnsmasq --pidfile /var/run/libvirt/network/default.pid
+                fi
+		start-stop-daemon --start --quiet --pidfile /var/run/libvirtd.pid --exec /usr/sbin/libvirtd -- --daemon --listen
+                log_end_msg $?
+                ;;
+        stop)
+                log_begin_msg "Stopping virtualization library daemon: libvirtd"
+		start-stop-daemon --stop --quiet --retry 3 --exec /usr/sbin/libvirtd --pidfile /var/run/libvirtd.pid
+                log_end_msg $?
+                rm -f /var/run/libvirtd.pid
+                ;;
+        restart)
+                $0 stop
+                sleep 1
+                $0 start
+                ;;
+        *)
+                echo "Usage: $0 {start|stop|restart}"
+                exit 1
+                ;;
+esac

--- a/dynamic-layers/virtualization-layer/recipes-extended/libvirt/acrn-libvirt/qemu-fix-crash-in-qemuOpen.patch
+++ b/dynamic-layers/virtualization-layer/recipes-extended/libvirt/acrn-libvirt/qemu-fix-crash-in-qemuOpen.patch
@@ -1,0 +1,39 @@
+From 74bff2509080912ea8abf1de8fd95fa2412b659a Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?J=C3=A1n=20Tomko?= <jtomko@redhat.com>
+Date: Thu, 11 Apr 2013 11:37:25 +0200
+Subject: [PATCH] qemu: fix crash in qemuOpen
+
+commit 74bff2509080912ea8abf1de8fd95fa2412b659a from upsteam
+git://libvirt.org/libvirt.git
+
+If the path part of connection URI is not present, cfg is used
+unitialized.
+
+https://bugzilla.redhat.com/show_bug.cgi?id=950855
+---
+ src/qemu/qemu_driver.c |    2 +-
+ 1 files changed, 1 insertions(+), 1 deletions(-)
+
+diff --git a/src/qemu/qemu_driver.c b/src/qemu/qemu_driver.c
+index 2c0d7d1..0d41e39 100644
+--- a/src/qemu/qemu_driver.c
++++ b/src/qemu/qemu_driver.c
+@@ -1026,6 +1026,7 @@ static virDrvOpenStatus qemuOpen(virConnectPtr conn,
+             goto cleanup;
+         }
+ 
++        cfg = virQEMUDriverGetConfig(qemu_driver);
+         if (conn->uri->path == NULL) {
+             virReportError(VIR_ERR_INTERNAL_ERROR,
+                            _("no QEMU URI path given, try %s"),
+@@ -1033,7 +1034,6 @@ static virDrvOpenStatus qemuOpen(virConnectPtr conn,
+             goto cleanup;
+         }
+ 
+-        cfg = virQEMUDriverGetConfig(qemu_driver);
+         if (cfg->privileged) {
+             if (STRNEQ(conn->uri->path, "/system") &&
+                 STRNEQ(conn->uri->path, "/session")) {
+-- 
+1.7.1
+

--- a/dynamic-layers/virtualization-layer/recipes-extended/libvirt/acrn-libvirt/run-ptest
+++ b/dynamic-layers/virtualization-layer/recipes-extended/libvirt/acrn-libvirt/run-ptest
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+make -C tests -k check-TESTS

--- a/dynamic-layers/virtualization-layer/recipes-extended/libvirt/acrn-libvirt/runptest.patch
+++ b/dynamic-layers/virtualization-layer/recipes-extended/libvirt/acrn-libvirt/runptest.patch
@@ -1,0 +1,116 @@
+From 9d6bfb4a5e9b44c080ddf3bad4c364ffb0e9d84a Mon Sep 17 00:00:00 2001
+From: Dengke Du <dengke.du@windriver.com>
+Date: Wed, 8 May 2019 10:20:47 +0800
+Subject: [PATCH] Add 'install-ptest' rule
+
+Change TESTS_ENVIRONMENT to allow running outside build dir.
+
+Upstream-status: Pending
+Signed-off-by: Mihaela Sendrea <mihaela.sendrea@enea.com>
+[KK: Update context for 1.3.5.]
+Signed-off-by: Kai Kang <kai.kang@windriver.com>
+[MA: Allow separate source and build dirs]
+Signed-off-by: Mark Asselstine <mark.asselstine@windriver.com>
+[ZH: add missing test_helper files]
+Signed-off-by: He Zhe <zhe.he@windriver.com>
+[MA: Update context for v4.3.0]
+Signed-off-by: Mark Asselstine <mark.asselstine@windriver.com>
+[DDU: Update context for v5.3.0]
+Signed-off-by: Dengke Du <dengke.du@windriver.com>
+
+---
+ tests/Makefile.am | 68 +++++++++++++++++++++++++++++++++++++++++------
+ 1 file changed, 60 insertions(+), 8 deletions(-)
+
+diff --git a/tests/Makefile.am b/tests/Makefile.am
+index 83326db..7a0aee3 100644
+--- a/tests/Makefile.am
++++ b/tests/Makefile.am
+@@ -28,11 +28,13 @@ AM_CPPFLAGS = \
+ 
+ WARN_CFLAGS += $(RELAXED_FRAME_LIMIT_CFLAGS)
+ 
++PTEST_DIR ?= $(libdir)/libvirt/ptest
++
+ AM_CFLAGS = \
+-	-Dabs_builddir="\"$(abs_builddir)\"" \
+-	-Dabs_top_builddir="\"$(abs_top_builddir)\"" \
+-	-Dabs_srcdir="\"$(abs_srcdir)\"" \
+-	-Dabs_top_srcdir="\"$(abs_top_srcdir)\"" \
++	-Dabs_builddir="\"$(PTEST_DIR)/tests\"" \
++	-Dabs_top_builddir="\"$(PTEST_DIR)\"" \
++	-Dabs_srcdir="\"$(PTEST_DIR)/tests\"" \
++	-Dabs_top_srcdir="\"$(PTEST_DIR)\"" \
+ 	$(LIBXML_CFLAGS) \
+ 	$(GLIB_CFLAGS) \
+ 	$(LIBNL_CFLAGS) \
+@@ -472,10 +474,10 @@ TESTS = $(test_programs) \
+ 
+ VIR_TEST_EXPENSIVE ?= $(VIR_TEST_EXPENSIVE_DEFAULT)
+ TESTS_ENVIRONMENT = \
+-  abs_top_builddir="$(abs_top_builddir)" \
+-  abs_top_srcdir="$(abs_top_srcdir)" \
+-  abs_builddir="$(abs_builddir)" \
+-  abs_srcdir="$(abs_srcdir)" \
++  abs_top_builddir="$(PTEST_DIR)" \
++  abs_top_srcdir="$(PTEST_DIR)" \
++  abs_builddir="$(PTEST_DIR)/tests" \
++  abs_srcdir="$(PTEST_DIR)/tests" \
+   LIBVIRT_AUTOSTART=0 \
+   LC_ALL=C \
+   VIR_TEST_EXPENSIVE=$(VIR_TEST_EXPENSIVE) \
+@@ -1549,4 +1551,54 @@ else ! WITH_LINUX
+ EXTRA_DIST += virscsitest.c
+ endif  ! WITH_LINUX
+ 
++buildtest-TESTS: $(TESTS) $(test_libraries) $(test_helpers)
++
++PTESTS = $(TESTS) $(test_helpers) test-lib.sh virschematest
++
++install-ptest:
++	list='$(TESTS) $(test_helpers) test-lib.sh virschematest'
++	install -d $(DEST_DIR)/tools
++	@(if [ -d ../tools/.libs ] ; then cd ../tools/.libs; fi; \
++	install * $(DEST_DIR)/tools)
++	install -d $(DEST_DIR)/src/network
++	cp $(top_srcdir)/src/network/*.xml $(DEST_DIR)/src/network
++	install -d $(DEST_DIR)/src/cpu_map
++	cp $(top_srcdir)/src/cpu_map/*.xml $(DEST_DIR)/src/cpu_map
++	install ../src/libvirt_iohelper $(DEST_DIR)/src
++	install -D ../src/libvirtd $(DEST_DIR)/src/libvirtd
++	install -d $(DEST_DIR)/src/remote
++	install -D $(top_srcdir)/../build/src/remote/libvirtd.conf $(DEST_DIR)/src/remote/libvirtd.conf
++	install -d $(DEST_DIR)/src/remote/.libs
++	@(if [ -d ../src/remote/.libs ] ; then cd ../src/remote/.libs; fi; \
++	install * $(DEST_DIR)/src/remote/.libs)
++	install -d $(DEST_DIR)/src/.libs
++	@(if [ -d ../src/.libs ] ; then cd ../src/.libs; fi; \
++	install * $(DEST_DIR)/src/.libs)
++	install -d $(DEST_DIR)/docs/schemas
++	cp $(top_srcdir)/docs/schemas/*.rng $(DEST_DIR)/docs/schemas
++	cp -r $(top_srcdir)/build-aux $(DEST_DIR)
++	install -d $(DEST_DIR)/examples/xml
++	cp -r $(top_srcdir)/examples/xml/test $(DEST_DIR)/examples/xml
++	install -d $(DEST_DIR)/tests/.libs
++	find . -type d -name "*xml2xml*" -exec cp -r {} $(DEST_DIR)/tests \;
++	find . -type d -name "*data" -exec cp -r {} $(DEST_DIR)/tests \;
++	@(for file in $(PTESTS); do \
++		if [ -f .libs/$$file ]; then \
++			install .libs/$$file $(DEST_DIR)/tests; \
++		elif [ -f $(srcdir)/$$file ]; then \
++			install $(srcdir)/$$file $(DEST_DIR)/tests; \
++		else \
++			install $(builddir)/$$file $(DEST_DIR)/tests; \
++		fi; \
++	done;)
++	@(if [ -d .libs ]; then install .libs/*.so $(DEST_DIR)/tests/.libs; fi;)
++	cp ../config.h $(DEST_DIR)
++	cp Makefile $(DEST_DIR)/tests
++	sed -i -e 's/^Makefile:/_Makefile:/' $(DEST_DIR)/tests/Makefile
++	cp ../Makefile $(DEST_DIR)
++	sed -i -e 's|^Makefile:|_Makefile:|' $(DEST_DIR)/Makefile
++	sed -i -e 's|$(BUILD_DIR)|$(PTEST_DIR)|g' $(DEST_DIR)/tests/Makefile
++	sed -i -e 's|$(BUILD_DIR)|$(PTEST_DIR)|g' $(DEST_DIR)/Makefile
++	sed -i -e 's|^\(.*\.log:\) \(.*EXEEXT.*\)|\1|g' $(DEST_DIR)/tests/Makefile
++
+ CLEANFILES = *.cov *.gcov .libs/*.gcda .libs/*.gcno *.gcno *.gcda

--- a/dynamic-layers/virtualization-layer/recipes-extended/libvirt/acrn-libvirt/tools-add-libvirt-net-rpc-to-virt-host-validate-when.patch
+++ b/dynamic-layers/virtualization-layer/recipes-extended/libvirt/acrn-libvirt/tools-add-libvirt-net-rpc-to-virt-host-validate-when.patch
@@ -1,0 +1,91 @@
+From a1696741375c6faca0d09ae6b271a2c56fc2b6fe Mon Sep 17 00:00:00 2001
+From: Dengke Du <dengke.du@windriver.com>
+Date: Tue, 7 May 2019 15:26:32 +0800
+Subject: [PATCH] tools: add libvirt-net-rpc to virt-host-validate when TLS is
+ enabled
+
+When gnu-tls is enabled for libvirt references to virNetTLSInit are
+generated in libvirt. Any binaries linking against libvirt, must also
+link against libvirt-net-rpc which provides the implementation.
+
+Signed-off-by: Bruce Ashfield <bruce.ashfield@windriver.com>
+[ywei: rebased to libvirt-1.3.2]
+Signed-off-by: Yunguo Wei <yunguo.wei@windriver.com>
+[MA: rebase to v4.3.0]
+Signed-off-by: Mark Asselstine <mark.asselstine@windriver.com>
+[ddu: rebase to v5.3.0]
+Signed-off-by: Dengke Du <dengke.du@windriver.com>
+
+---
+ examples/Makefile.am | 20 ++++++++++++++++++++
+ tools/Makefile.am    | 12 ++++++++++++
+ 2 files changed, 32 insertions(+)
+
+diff --git a/examples/Makefile.am b/examples/Makefile.am
+index ad635bd..a94f41d 100644
+--- a/examples/Makefile.am
++++ b/examples/Makefile.am
+@@ -74,6 +74,10 @@ LDADD = \
+ 	$(top_builddir)/src/libvirt-admin.la \
+ 	$(NULL)
+ 
++if WITH_GNUTLS
++LDADD += $(top_builddir)/src/libvirt-net-rpc.la
++endif
++
+ noinst_PROGRAMS = \
+ 	c/admin/client_close \
+ 	c/admin/client_info \
+@@ -111,6 +115,22 @@ c_misc_openauth_SOURCES = c/misc/openauth.c
+ examplesdir = $(docdir)/examples
+ 
+ adminexamplesdir = $(examplesdir)/c/admin
++
++if WITH_GNUTLS
++dominfo_info1_LDADD = $(top_builddir)/src/libvirt-net-rpc.la  \
++               $(LDADD)    \
++               $(NULL)
++domsuspend_suspend_LDADD = $(top_builddir)/src/libvirt-net-rpc.la  \
++               $(LDADD)    \
++               $(NULL)
++hellolibvirt_hellolibvirt_LDADD = $(top_builddir)/src/libvirt-net-rpc.la  \
++               $(LDADD)    \
++               $(NULL)
++openauth_openauth_LDADD = $(top_builddir)/src/libvirt-net-rpc.la  \
++               $(LDADD)   \
++               $(NULL)
++endif
++
+ adminexamples_DATA = $(ADMIN_EXAMPLES)
+ 
+ domainexamplesdir = $(examplesdir)/c/domain
+diff --git a/tools/Makefile.am b/tools/Makefile.am
+index 53df930..2a0a989 100644
+--- a/tools/Makefile.am
++++ b/tools/Makefile.am
+@@ -166,6 +166,12 @@ virt_host_validate_LDADD = \
+ 		$(GLIB_LIBS) \
+ 		$(NULL)
+ 
++if WITH_GNUTLS
++virt_host_validate_LDADD += ../src/libvirt-net-rpc.la \
++                            ../gnulib/lib/libgnu.la   \
++                            $(NULL)
++endif
++
+ virt_host_validate_CFLAGS = \
+ 		$(AM_CFLAGS) \
+ 		$(NULL)
+@@ -262,6 +268,12 @@ virt_admin_CFLAGS = \
+ 		$(READLINE_CFLAGS)
+ BUILT_SOURCES =
+ 
++if WITH_GNUTLS
++virsh_LDADD += ../src/libvirt-net-rpc.la \
++               ../gnulib/lib/libgnu.la   \
++               $(NULL)
++endif
++
+ if WITH_WIN_ICON
+ virsh_LDADD += virsh_win_icon.$(OBJEXT)
+ 

--- a/dynamic-layers/virtualization-layer/recipes-extended/libvirt/acrn-libvirt_6.1.0.bb
+++ b/dynamic-layers/virtualization-layer/recipes-extended/libvirt/acrn-libvirt_6.1.0.bb
@@ -1,0 +1,460 @@
+DESCRIPTION = "A toolkit to interact with the virtualization capabilities of recent versions of Linux." 
+HOMEPAGE = "http://libvirt.org"
+LICENSE = "LGPLv2.1+ & GPLv2+"
+LICENSE_${PN}-ptest = "GPLv2+ & LGPLv2.1+"
+LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
+                    file://COPYING.LESSER;md5=4b54a1fd55a448865a0b32d41598759d"
+SECTION = "console/tools"
+
+DEPENDS = "bridge-utils gnutls libxml2 lvm2 avahi parted curl libpcap util-linux e2fsprogs pm-utils \
+	   iptables dnsmasq readline libtasn1 libxslt-native acl libdevmapper libtirpc \
+           python3-docutils-native \
+	   ${@bb.utils.contains('PACKAGECONFIG', 'polkit', 'shadow-native', '', d)} \
+	   ${@bb.utils.contains('PACKAGECONFIG', 'gnutls', 'gnutls-native', '', d)}"
+
+# libvirt-guests.sh needs gettext.sh
+#
+RDEPENDS_${PN} = "gettext-runtime"
+
+RDEPENDS_${PN}-ptest += "make gawk perl bash"
+
+RDEPENDS_${PN}-libvirtd += "bridge-utils iptables pm-utils dnsmasq netcat-openbsd"
+RDEPENDS_${PN}-libvirtd_append_x86-64 = " dmidecode"
+RDEPENDS_${PN}-libvirtd_append_x86 = " dmidecode"
+
+#connman blocks the 53 port and libvirtd can't start its DNS service
+RCONFLICTS_${PN}_libvirtd = "connman"
+
+SRC_URI = "git://github.com/projectacrn/acrn-libvirt.git;branch=${SRCBRANCH};destsuffix=acrn-libvirt-${PV};name=libvirt \
+           git://gitlab.com/keycodemap/keycodemapdb.git;protocol=https;destsuffix=acrn-libvirt-${PV}/src/keycodemapdb;name=keycodemapdb \
+           file://tools-add-libvirt-net-rpc-to-virt-host-validate-when.patch \
+           file://libvirtd.sh \
+           file://libvirtd.conf \
+           file://dnsmasq.conf \
+           file://runptest.patch \
+           file://run-ptest \
+           file://libvirt-use-pkg-config-to-locate-libcap.patch \
+           file://install-missing-file.patch \
+           file://0001-ptest-Remove-Windows-1252-check-from-esxutilstest.patch \
+           file://configure.ac-search-for-rpc-rpc.h-in-the-sysroot.patch \
+           file://0001-build-drop-unnecessary-libgnu.la-reference.patch \
+           file://hook_support.py \
+           file://gnutls-helper.py \
+          "
+
+SRCBRANCH = "dev-acrn-v6.1.0"
+# with acrn v6.1.0
+SRCREV_libvirt = "5da2711f895a8a4bcdda16243e0f3d6134c83cf1"
+SRCREV_keycodemapdb = "27acf0ef828bf719b2053ba398b195829413dbdd"
+
+inherit autotools gettext update-rc.d pkgconfig ptest systemd useradd perlnative
+USERADD_PACKAGES = "${PN}"
+GROUPADD_PARAM_${PN} = "-r qemu; -r kvm"
+USERADD_PARAM_${PN} = "-r -g qemu -G kvm qemu"
+
+# Override the default set in autotools.bbclass so that we will use relative pathnames
+# to our local m4 files.  This prevents an "Argument list too long" error during configuration
+# if our project is in a directory with an absolute pathname of more than about 125 characters.
+#
+acpaths = "-I ./m4"
+
+CACHED_CONFIGUREVARS += "\
+ac_cv_path_XMLCATLOG=/usr/bin/xmlcatalog \
+ac_cv_path_AUGPARSE=/usr/bin/augparse \
+ac_cv_path_DNSMASQ=/usr/bin/dnsmasq \
+ac_cv_path_BRCTL=/usr/sbin/brctl \
+ac_cv_path_TC=/sbin/tc \
+ac_cv_path_UDEVADM=/sbin/udevadm \
+ac_cv_path_MODPROBE=/sbin/modprobe \
+ac_cv_path_IP_PATH=/bin/ip \
+ac_cv_path_IPTABLES_PATH=/usr/sbin/iptables \
+ac_cv_path_IP6TABLES_PATH=/usr/sbin/ip6tables \
+ac_cv_path_MOUNT=/bin/mount \
+ac_cv_path_UMOUNT=/bin/umount \
+ac_cv_path_MKFS=/usr/sbin/mkfs \
+ac_cv_path_SHOWMOUNT=/usr/sbin/showmount \
+ac_cv_path_PVCREATE=/usr/sbin/pvcreate \
+ac_cv_path_VGCREATE=/usr/sbin/vgcreate \
+ac_cv_path_LVCREATE=/usr/sbin/lvcreate \
+ac_cv_path_PVREMOVE=/usr/sbin/pvremove \
+ac_cv_path_VGREMOVE=/usr/sbin/vgremove \
+ac_cv_path_LVREMOVE=/usr/sbin/lvremove \
+ac_cv_path_LVCHANGE=/usr/sbin/lvchange \
+ac_cv_path_VGCHANGE=/usr/sbin/vgchange \
+ac_cv_path_VGSCAN=/usr/sbin/vgscan \
+ac_cv_path_PVS=/usr/sbin/pvs \
+ac_cv_path_VGS=/usr/sbin/vgs \
+ac_cv_path_LVS=/usr/sbin/lvs \
+ac_cv_path_PARTED=/usr/sbin/parted \
+ac_cv_path_DMSETUP=/usr/sbin/dmsetup"
+
+# Ensure that libvirt uses polkit rather than policykit, whether the host has
+# pkcheck installed or not, and ensure the path is correct per our config.
+CACHED_CONFIGUREVARS += "ac_cv_path_PKCHECK_PATH=${bindir}/pkcheck"
+
+# Some other possible paths we are not yet setting
+#ac_cv_path_RPCGEN=
+#ac_cv_path_XSLTPROC=
+#ac_cv_path_RADVD=
+#ac_cv_path_UDEVSETTLE=
+#ac_cv_path_EBTABLES_PATH=
+#ac_cv_path_PKG_CONFIG=
+#ac_cv_path_ac_pt_PKG_CONFIG
+#ac_cv_path_POLKIT_AUTH=
+#ac_cv_path_DTRACE=
+#ac_cv_path_ISCSIADM=
+#ac_cv_path_MSGFMT=
+#ac_cv_path_GMSGFMT=
+#ac_cv_path_XGETTEXT=
+#ac_cv_path_MSGMERGE=
+#ac_cv_path_SCRUB=
+#ac_cv_path_PYTHON=
+
+ALLOW_EMPTY_${PN} = "1"
+
+PACKAGES =+ "${PN}-libvirtd ${PN}-virsh"
+
+ALLOW_EMPTY_${PN}-libvirtd = "1"
+
+FILES_${PN}-libvirtd = " \
+	${sysconfdir}/init.d \
+	${sysconfdir}/sysctl.d \
+	${sysconfdir}/logrotate.d \
+	${sysconfdir}/libvirt/libvirtd.conf \
+        /usr/lib/sysctl.d/60-libvirtd.conf \
+	${sbindir}/libvirtd \
+	${systemd_unitdir}/system/* \
+	${@bb.utils.contains('DISTRO_FEATURES', 'sysvinit', '', '${libexecdir}/libvirt-guests.sh', d)} \
+	${@bb.utils.contains('PACKAGECONFIG', 'gnutls', '${sysconfdir}/pki/libvirt/* ${sysconfdir}/pki/CA/*', '', d)} \
+        "
+
+FILES_${PN}-virsh = " \
+    ${bindir}/virsh \
+    ${datadir}/bash-completion/completions/virsh \
+"
+
+FILES_${PN} += "${libdir}/libvirt/connection-driver \
+	    ${datadir}/augeas \
+	    ${@bb.utils.contains('PACKAGECONFIG', 'polkit', '${datadir}/polkit-1', '', d)} \
+	    ${datadir}/bash-completion/completions/vsh \
+	    ${datadir}/bash-completion/completions/virt-admin \
+	    ${datadir}/libvirt/api \
+	    ${datadir}/libvirt/cpu_map \
+	    ${datadir}/libvirt/schemas \
+	    ${datadir}/libvirt/test-screenshot.png \
+	    /usr/lib/firewalld/zones/libvirt.xml \
+	    "
+
+FILES_${PN}-dbg += "${libdir}/libvirt/connection-driver/.debug ${libdir}/libvirt/lock-driver/.debug"
+FILES_${PN}-staticdev += "${libdir}/*.a ${libdir}/libvirt/connection-driver/*.a ${libdir}/libvirt/lock-driver/*.a"
+
+CONFFILES_${PN} += "${sysconfdir}/libvirt/libvirt.conf \
+                    ${sysconfdir}/libvirt/lxc.conf \
+                    ${sysconfdir}/libvirt/qemu-lockd.conf \
+                    ${sysconfdir}/libvirt/qemu.conf \
+                    ${sysconfdir}/libvirt/virt-login-shell.conf \
+                    ${sysconfdir}/libvirt/virtlockd.conf"
+
+CONFFILES_${PN}-libvirtd = "${sysconfdir}/logrotate.d/libvirt ${sysconfdir}/logrotate.d/libvirt.lxc \
+                            ${sysconfdir}/logrotate.d/libvirt.qemu ${sysconfdir}/logrotate.d/libvirt.uml \
+                            ${sysconfdir}/libvirt/libvirtd.conf \
+                            /usr/lib/sysctl.d/libvirtd.conf"
+
+INITSCRIPT_PACKAGES = "${PN}-libvirtd"
+INITSCRIPT_NAME_${PN}-libvirtd = "libvirtd"
+INITSCRIPT_PARAMS_${PN}-libvirtd = "defaults 72"
+
+SYSTEMD_PACKAGES = "${PN}-libvirtd"
+SYSTEMD_SERVICE_${PN}-libvirtd = " \
+    libvirtd.service \
+    virtlockd.service \
+    libvirt-guests.service \
+    virtlockd.socket \
+    "
+
+
+PRIVATE_LIBS_${PN}-ptest = " \
+	libvirt-lxc.so.0 \
+	libvirt.so.0 \
+	libvirt-qemu.so.0 \
+	lockd.so \
+	libvirt_driver_secret.so \
+	libvirt_driver_nodedev.so \
+	libvirt_driver_vbox.so \
+	libvirt_driver_interface.so \
+	libvirt_driver_uml.so \
+	libvirt_driver_network.so \
+	libvirt_driver_nwfilter.so \
+	libvirt_driver_qemu.so \
+	libvirt_driver_storage.so \
+	libvirt_driver_lxc.so \
+    "
+
+# xen-minimal config
+#PACKAGECONFIG ??= "xen libxl xen-inotify test remote libvirtd"
+
+# full config
+PACKAGECONFIG ??= "qemu yajl openvz vmware vbox esx iproute2 lxc test \
+                   remote macvtap libvirtd netcf udev python ebtables \
+                   fuse iproute2 firewalld libpcap acrn \
+                   ${@bb.utils.contains('DISTRO_FEATURES', 'selinux', 'selinux audit libcap-ng', '', d)} \
+                   ${@bb.utils.contains('DISTRO_FEATURES', 'xen', 'libxl', '', d)} \
+                   ${@bb.utils.contains('DISTRO_FEATURES', 'polkit', 'polkit', '', d)} \
+                  "
+# acrn config recommended from ACRN Team
+PACKAGECONFIG = "acrn remote macvtap libvirtd netcf udev ebtables fuse iproute2 firewalld libpcap test python "
+
+# qemu is NOT compatible with mips64
+PACKAGECONFIG_remove_mipsarchn32 = "qemu"
+PACKAGECONFIG_remove_mipsarchn64 = "qemu"
+
+# numactl is NOT compatible with arm
+PACKAGECONFIG_remove_arm = "numactl"
+PACKAGECONFIG_remove_armeb = "numactl"
+
+# enable,disable,depends,rdepends
+#
+PACKAGECONFIG[gnutls] = ",,,gnutls-bin"
+PACKAGECONFIG[qemu] = "--with-qemu --with-qemu-user=qemu --with-qemu-group=qemu,--without-qemu,qemu,"
+PACKAGECONFIG[yajl] = "--with-yajl,--without-yajl,yajl,yajl"
+PACKAGECONFIG[libxl] = "--with-libxl=${STAGING_DIR_TARGET}/lib,--without-libxl,xen,"
+PACKAGECONFIG[openvz] = "--with-openvz,--without-openvz,,"
+PACKAGECONFIG[vmware] = "--with-vmware,--without-vmware,,"
+PACKAGECONFIG[vbox] = "--with-vbox,--without-vbox,,"
+PACKAGECONFIG[esx] = "--with-esx,--without-esx,,"
+PACKAGECONFIG[hyperv] = "--with-hyperv,--without-hyperv,,"
+PACKAGECONFIG[polkit] = "--with-polkit,--without-polkit,polkit,polkit"
+PACKAGECONFIG[lxc] = "--with-lxc,--without-lxc, lxc,"
+PACKAGECONFIG[test] = "--with-test=yes,--with-test=no,,"
+PACKAGECONFIG[remote] = "--with-remote,--without-remote,,"
+PACKAGECONFIG[macvtap] = "--with-macvtap=yes,--with-macvtap=no,libnl,libnl"
+PACKAGECONFIG[libvirtd] = "--with-libvirtd,--without-libvirtd,,"
+PACKAGECONFIG[netcf] = "--with-netcf,--without-netcf,netcf,netcf"
+PACKAGECONFIG[dtrace] = "--with-dtrace,--without-dtrace,,"
+PACKAGECONFIG[udev] = "--with-udev --with-pciaccess,--without-udev,udev libpciaccess,"
+PACKAGECONFIG[selinux] = "--with-selinux,--without-selinux,libselinux,"
+PACKAGECONFIG[ebtables] = "ac_cv_path_EBTABLES_PATH=/sbin/ebtables,ac_cv_path_EBTABLES_PATH=,ebtables,ebtables"
+PACKAGECONFIG[python] = ",,python3,"
+PACKAGECONFIG[sasl] = "--with-sasl,--without-sasl,cyrus-sasl,cyrus-sasl"
+PACKAGECONFIG[iproute2] = "ac_cv_path_IP_PATH=/sbin/ip,ac_cv_path_IP_PATH=,iproute2,iproute2"
+PACKAGECONFIG[numactl] = "--with-numactl,--without-numactl,numactl,"
+PACKAGECONFIG[fuse] = "--with-fuse,--without-fuse,fuse,"
+PACKAGECONFIG[audit] = "--with-audit,--without-audit,audit,"
+PACKAGECONFIG[libcap-ng] = "--with-capng,--without-capng,libcap-ng,"
+PACKAGECONFIG[wireshark] = "--with-wireshark-dissector,--without-wireshark-dissector,wireshark libwsutil,"
+PACKAGECONFIG[apparmor-profiles] = "--with-apparmor-profiles, --without-apparmor-profiles,"
+PACKAGECONFIG[firewalld] = "--with-firewalld, --without-firewalld,"
+PACKAGECONFIG[libpcap] = "--with-libpcap, --without-libpcap,libpcap,libpcap"
+PACKAGECONFIG[numad] = "--with-numad, --without-numad,"
+PACKAGECONFIG[acrn] = "--with-acrn,--without-acrn,,acrn-devicemodel acrn-tools"
+
+# Enable the Python tool support
+require libvirt-python.inc
+
+# acrn-libvirt is supported by linux-intel 5.4.46 and ACRN 2.0 onward, so
+# Skip processing of this recipe if linux-intel-acrn-sos is not explicitly specified as the
+# PREFERRED_PROVIDER for virtual/kernel, PREFERRED_VERSION to 5.4 and PREFERRED_PROVIDER for acrn-hypervisor
+# to acrn-hypervisor-dev recipes, which is pointing to 2.0 and higher.
+# This avoids runtime libvirt-acrn failures
+python () {
+    if not (d.getVar("PREFERRED_PROVIDER_virtual/kernel") == "linux-intel-acrn-sos" and \
+        d.getVar("PREFERRED_PROVIDER_acrn-hypervisor") == "acrn-hypervisor-dev") :
+            bb.warn("!! ACRN libvirt is not supported by ACRN 1.6.1 and 4.19 kernel, You might face runtime failures !!")
+}
+
+EXTRA_OECONF_append = " --disable-werror"
+do_configure_prepend () {
+    olddir=`pwd`
+    cd ${S}
+    autoreconf --verbose --force --install
+    cd $olddir
+}
+
+
+do_compile() {
+	cd ${B}/src
+	# There may be race condition, but without creating these directories
+	# in the source tree, generation of files fails.
+	for i in access admin logging esx locking rpc hyperv lxc \
+		    remote network storage interface nwfilter node_device \
+		    secret vbox qemu acrn; do
+		mkdir -p $i;
+	done
+
+	cd ${B}
+	export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:${B}/src:"
+	oe_runmake all
+}
+
+do_install_prepend() {
+	# so the install routines can find the libvirt.pc in the source dir
+	export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:${B}/src:"
+}
+
+do_install_append() {
+	install -d ${D}/etc/init.d
+	install -d ${D}/etc/libvirt
+	install -d ${D}/etc/dnsmasq.d
+
+	install -m 0755 ${WORKDIR}/libvirtd.sh ${D}/etc/init.d/libvirtd
+	install -m 0644 ${WORKDIR}/libvirtd.conf ${D}/etc/libvirt/libvirtd.conf
+
+	if ${@bb.utils.contains('DISTRO_FEATURES','sysvinit','true','false',d)}; then
+	    # This will wind up in the libvirtd package, but will NOT be invoked by default.
+	    #
+	    mv ${D}/${libexecdir}/libvirt-guests.sh ${D}/${sysconfdir}/init.d
+	fi
+
+	if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
+	    # This variable is used by libvirtd.service to start libvirtd in the right mode
+	    sed -i '/#LIBVIRTD_ARGS="--listen"/a LIBVIRTD_ARGS="--listen --daemon"' ${D}/${sysconfdir}/sysconfig/libvirtd
+
+	    # We can't use 'notify' when we don't support 'sd_notify' dbus capabilities.
+	    sed -i -e 's/Type=notify/Type=forking/' \
+	           -e '/Type=forking/a PIDFile=${localstatedir}/run/libvirtd.pid' \
+		   ${D}/${systemd_unitdir}/system/libvirtd.service
+	fi
+
+	# The /var/run/libvirt directories created by the Makefile
+	# are wiped out in volatile, we need to create these at boot.
+	rm -rf ${D}${localstatedir}/run
+	install -d ${D}${sysconfdir}/default/volatiles
+	echo "d root root 0755 ${localstatedir}/run/libvirt none" \
+	     > ${D}${sysconfdir}/default/volatiles/99_libvirt
+	echo "d root root 0755 ${localstatedir}/run/libvirt/lockd none" \
+	     >> ${D}${sysconfdir}/default/volatiles/99_libvirt
+	echo "d root root 0755 ${localstatedir}/run/libvirt/lxc none" \
+	     >> ${D}${sysconfdir}/default/volatiles/99_libvirt
+	echo "d root root 0755 ${localstatedir}/run/libvirt/network none" \
+	     >> ${D}${sysconfdir}/default/volatiles/99_libvirt
+	echo "d root root 0755 ${localstatedir}/run/libvirt/qemu none" \
+	     >> ${D}${sysconfdir}/default/volatiles/99_libvirt
+
+	# Manually set permissions and ownership to match polkit recipe
+	if ${@bb.utils.contains('PACKAGECONFIG', 'polkit', 'true', 'false', d)}; then
+		install -d -m 0700 ${D}/${datadir}/polkit-1/rules.d
+		chown polkitd ${D}/${datadir}/polkit-1/rules.d
+		chgrp root ${D}/${datadir}/polkit-1/rules.d
+	else
+		rm -rf ${D}/${datadir}/polkit-1
+	fi
+
+	# disable seccomp_sandbox
+        if [ -e ${D}${sysconfdir}/libvirt/qemu.conf ] ; then
+	   sed -i '/^#seccomp_sandbox = 1/aseccomp_sandbox = 0' \
+	       ${D}${sysconfdir}/libvirt/qemu.conf
+        fi
+
+	# Add hook support for libvirt
+	mkdir -p ${D}/etc/libvirt/hooks
+	for hook in "daemon" "lxc" "network" "qemu"
+	do
+		install -m 0755 ${WORKDIR}/hook_support.py ${D}/etc/libvirt/hooks/${hook}
+	done
+
+	# Force the main dnsmasq instance to bind only to specified interfaces and
+	# to not bind to virbr0. Libvirt will run its own instance on this interface.
+	install -m 644 ${WORKDIR}/dnsmasq.conf ${D}/${sysconfdir}/dnsmasq.d/libvirt-daemon
+
+	# remove .la references to our working diretory
+	for i in `find ${D}${libdir} -type f -name *.la`; do
+	    sed -i -e 's#-L${B}/src/.libs##g' $i
+	done
+
+	sed -i -e 's/^\(unix_sock_group\ =\ \).*/\1"kvm"/' ${D}/etc/libvirt/libvirtd.conf
+	sed -i -e 's/^\(unix_sock_rw_perms\ =\ \).*/\1"0776"/' ${D}/etc/libvirt/libvirtd.conf
+
+	case ${MACHINE_ARCH} in
+		*mips*)
+			break
+			;;
+		*)
+			if ${@bb.utils.contains('PACKAGECONFIG','qemu','true','false',d)}; then
+			    chown -R qemu:qemu ${D}/${localstatedir}/lib/libvirt/qemu
+			    echo "d qemu qemu 0755 ${localstatedir}/cache/libvirt/qemu none" \
+			        >> ${D}${sysconfdir}/default/volatiles/99_libvirt
+			fi
+			break
+			;;
+	esac
+
+	if ${@bb.utils.contains('PACKAGECONFIG','gnutls','true','false',d)}; then
+	    # Generate sample keys and certificates.
+	    cd ${WORKDIR}
+	    ${WORKDIR}/gnutls-helper.py -y
+
+	    # Deploy all sample keys and certificates of CA, server and client
+	    # to target so that libvirtd is able to boot successfully and local
+	    # connection via 127.0.0.1 is available out of box.
+	    install -d ${D}/etc/pki/CA
+	    install -d ${D}/etc/pki/libvirt/private
+	    install -m 0755 ${WORKDIR}/gnutls-helper.py ${D}/${bindir}
+	    install -m 0644 ${WORKDIR}/cakey.pem ${D}/${sysconfdir}/pki/libvirt/private/cakey.pem
+	    install -m 0644 ${WORKDIR}/cacert.pem ${D}/${sysconfdir}/pki/CA/cacert.pem
+	    install -m 0644 ${WORKDIR}/serverkey.pem ${D}/${sysconfdir}/pki/libvirt/private/serverkey.pem
+	    install -m 0644 ${WORKDIR}/servercert.pem ${D}/${sysconfdir}/pki/libvirt/servercert.pem
+	    install -m 0644 ${WORKDIR}/clientkey.pem ${D}/${sysconfdir}/pki/libvirt/private/clientkey.pem
+	    install -m 0644 ${WORKDIR}/clientcert.pem ${D}/${sysconfdir}/pki/libvirt/clientcert.pem
+
+	    # Force the connection to be tls.
+	    sed -i -e 's/^\(listen_tls\ =\ .*\)/#\1/' -e 's/^\(listen_tcp\ =\ .*\)/#\1/' ${D}/etc/libvirt/libvirtd.conf
+	fi
+
+	# virt-login-shell needs to run with setuid permission
+	chmod 4755 ${D}${bindir}/virt-login-shell
+}
+
+EXTRA_OECONF += " \
+    --with-init-script=systemd \
+    --with-test-suite \
+    "
+
+# gcc9 end up mis-compiling qemuxml2argvtest.o with Og which then
+# crashes on target, so remove -Og and use -O2 as workaround
+SELECTED_OPTIMIZATION_remove_virtclass-multilib-lib32_mipsarch = "-Og"
+SELECTED_OPTIMIZATION_append_virtclass-multilib-lib32_mipsarch = " -O2"
+
+EXTRA_OEMAKE = "BUILD_DIR=${B} DEST_DIR=${D}${PTEST_PATH} PTEST_DIR=${PTEST_PATH} SYSTEMD_UNIT_DIR=${systemd_system_unitdir}"
+
+PRIVATE_LIBS_${PN}-ptest_append = "libvirt-admin.so.0"
+
+do_compile_ptest() {
+	oe_runmake -C tests buildtest-TESTS
+}
+
+do_install_ptest() {
+	oe_runmake -C tests install-ptest
+
+	find ${S}/tests -maxdepth 1 -type d -exec cp -r {} ${D}${PTEST_PATH}/tests/ \;
+
+	# remove .la files for ptest, they aren't required and can trigger QA errors
+	for i in `find ${D}${PTEST_PATH} -type f \( -name *.la -o -name *.o \)`; do
+                rm -f $i
+	done
+}
+
+pkg_postinst_${PN}() {
+        if [ -z "$D" ] && [ -e /etc/init.d/populate-volatile.sh ] ; then
+                /etc/init.d/populate-volatile.sh update
+        fi
+        mkdir -m 711 -p $D/data/images
+}
+
+python () {
+    if not bb.utils.contains('DISTRO_FEATURES', 'sysvinit', True, False, d):
+        d.setVar("INHIBIT_UPDATERCD_BBCLASS", "1")
+}
+
+PROVIDES_${PN} = "libvirt"
+RPROVIDES_${PN} += " libvirt"
+
+PROVIDES_${PN}-libvirtd = "libvirt-libvirtd"
+RPROVIDES_${PN}-libvirtd += " libvirt-libvirtd"
+
+PROVIDES_${PN}-virsh = "libvirt-virsh"
+RPROVIDES_${PN}-virsh += " libvirt-virsh"
+
+PROVIDES_${PN}-python = "libvirt-python"
+RPROVIDES_${PN}-python += " libvirt-python"
+
+RPROVIDES_${PN}-ptest += " libvirt-ptest "

--- a/dynamic-layers/virtualization-layer/recipes-extended/libvirt/libvirt-python.inc
+++ b/dynamic-layers/virtualization-layer/recipes-extended/libvirt/libvirt-python.inc
@@ -1,0 +1,62 @@
+inherit python3native python3-dir
+
+export STAGING_INCDIR
+export STAGING_LIBDIR
+export BUILD_SYS 
+export HOST_SYS
+
+RDEPENDS_${PN}-python += "python3"
+PACKAGECONFIG_${PN}-python[xen] = ",,,xen-python"
+
+PACKAGES += "${PN}-python-staticdev ${PN}-python-dev ${PN}-python-dbg ${PN}-python"
+
+FILES_${PN}-python-staticdev += "${PYTHON_SITEPACKAGES_DIR}/*.a"
+FILES_${PN}-python-dev += "${PYTHON_SITEPACKAGES_DIR}/*.la"
+FILES_${PN}-python-dbg += "${PYTHON_SITEPACKAGES_DIR}/.debug/"
+FILES_${PN}-python = "${bindir}/* ${libdir}/* ${libdir}/${PYTHON_DIR}/*"
+
+SRC_URI += "http://libvirt.org/sources/python/libvirt-python-${PV}.tar.gz;name=libvirt_python"
+
+SRC_URI[libvirt_python.md5sum] = "2834626b07da6ac4ca1559abfd55c118"
+SRC_URI[libvirt_python.sha256sum] = "be644f4809c0e1d368e3ac065df3c66a26dcfe61ecb607ee9706e1799f22c35a"
+
+export LIBVIRT_API_PATH = "${S}/docs/libvirt-api.xml"
+export LIBVIRT_CFLAGS = "-I${S}/include"
+export LIBVIRT_LIBS = "-L${B}/src/.libs -lvirt -ldl"
+export LDFLAGS="-L${B}/src/.libs"
+
+LIBVIRT_INSTALL_ARGS = "--root=${D} \
+    --prefix=${prefix} \
+    --install-lib=${PYTHON_SITEPACKAGES_DIR} \
+    --install-data=${datadir}"
+
+python __anonymous () {
+    pkgconfig = d.getVar('PACKAGECONFIG')
+    if ('python') in pkgconfig.split():
+        d.setVar('LIBVIRT_PYTHON_ENABLE', '1')
+    else:
+        d.setVar('LIBVIRT_PYTHON_ENABLE', '0')
+}
+
+do_compile_append() {
+	if [ "${LIBVIRT_PYTHON_ENABLE}" = "1" ]; then
+		# we need the python bindings to look into our source dir, not
+		# the syroot staged pkgconfig entries. So we clear the sysroot
+		# for just this portion.
+		export PKG_CONFIG_SYSROOT_DIR=
+		cd ${WORKDIR}/libvirt-python-${PV} && \
+		  ${STAGING_BINDIR_NATIVE}/python3-native/python3 setup.py build
+	fi
+}
+
+do_install_append() {
+	if [ "${LIBVIRT_PYTHON_ENABLE}" = "1" ]; then
+		# we need the python bindings to look into our source dir, not
+		# the syroot staged pkgconfig entries. So we clear the sysroot
+		# for just this portion.
+		export PKG_CONFIG_SYSROOT_DIR=
+		cd ${WORKDIR}/libvirt-python-${PV} && \
+		  ${STAGING_BINDIR_NATIVE}/python3-native/python3 setup.py install \
+                       --install-lib=${D}/${PYTHON_SITEPACKAGES_DIR} ${LIBVIRT_INSTALL_ARGS}
+	fi
+}


### PR DESCRIPTION
This recipe is based on libvirt recipe from meta-virtualization layer.
Fetching source from acrn-libvirt repo, which has ACRN HV support.
Added do_configure and source uri for keycodemapdb.Updated do_compile
and do_install. Dropped patches, which is not required anymore.

To build this recipe, add meta-virtualization and dependency layers
in bblayers.conf.

To ship in image, add below to local.conf

IMAGE_INSTALL_append = " libvirt libvirt-libvirtd libvirt-virsh"

acrn-libvirt is supported by ACRN 2.0 and linux-intel 5.4 versions only.

It should be build only for SOS.

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>