### PR TITLE
config: modify kernel physical start address

### DIFF
--- a/recipes-kernel/linux/files/sos.cfg
+++ b/recipes-kernel/linux/files/sos.cfg
@@ -32,3 +32,6 @@ CONFIG_OPENVSWITCH=m
 
 CONFIG_SERIAL_8250_EXTENDED=y
 CONFIG_SERIAL_8250_DETECT_IRQ=y
+
+# Let SOS kernel start from higher address to avoid its memory conflict with grub modules
+CONFIG_PHYSICAL_START=0x8000000


### PR DESCRIPTION
Previously SOS kernel physical start was set to 16MB, this would cause kernel
boot issue in the case that grub modules memory size is large than 15MB
(because the grub module is loaded from 1MB address so has memory overlap with
SOS load address).

In grub multiboot command, there is a --quirk-modules-after-kernel parameter
to fix this load issue, but the SOS might lost acpi environment because
multiboot does not support efi environment which includes acpi RSDP info. And
unfortunately multiboot2 command does not have --quirk-modules-after-kernel
support although it could pass efi environment to SOS.

So need to change SOS kernel load address to 128MB
	(i.e.	CONFIG_PHYSICAL_START=0x8000000)
to let SOS kernel start from higher address to avoid its memory conflict with
grub modules.

Tracked-On: projectacrn/acrn-hypervisor#5081
Signed-off-by: Victor Sun <victor.sun@intel.com>
Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>