### PR TITLE
Revert "linux-intel-rt-acrn-uos: update to v5.4.52-rt31"

### DIFF
--- a/recipes-kernel/linux/linux-intel-rt-acrn-uos_5.4.bb
+++ b/recipes-kernel/linux/linux-intel-rt-acrn-uos_5.4.bb
@@ -20,9 +20,9 @@ KMETA_BRANCH = "yocto-5.4"
 
 DEPENDS += "elfutils-native openssl-native util-linux-native"
 
-LINUX_VERSION ?= "5.4.52"
-SRCREV_machine ?= "bb4ae19664a898236b2af46b45a6a0fea23ab20d"
-SRCREV_meta ?= "caafbdfe382bf22a4786d871af097acd49d0867a"
+LINUX_VERSION ?= "5.4.44"
+SRCREV_machine ?= "2e8933a927e7de6ca0e6191c90666a5f00fd7241"
+SRCREV_meta ?= "b8c82ba37370e4698ff0c42f3e54b8b4f2fb4ac0"
 
 LINUX_VERSION_EXTENSION = "-linux-intel-preempt-rt-acrn-uos"
 
@@ -35,6 +35,3 @@ KERNEL_FEATURES_append = "features/netfilter/netfilter.scc \
                           features/net/stmicro/stmmac.cfg \
 "
 
-# Kernel config 'CONFIG_GPIO_LYNXPOINT' goes by a different name 'CONFIG_PINCTRL_LYNXPOINT' in
-# linux-intel. This cause warning during kernel config audit. So suppress the harmless warning for now.
-KCONF_BSP_AUDIT_LEVEL = "0"


### PR DESCRIPTION
X11 functionality with 5.4.52 breaks, it require ACRN Hypervisor patch
to support new IDV functionality coming along with 5.4.52.

This reverts commit 58948709169e13c779f341b03508193341a480be.