### PR TITLE
Revert "linux-intel-acrn: update to 5.4.52"

### DIFF
--- a/recipes-kernel/linux/linux-intel-acrn_5.4.inc
+++ b/recipes-kernel/linux/linux-intel-acrn_5.4.inc
@@ -9,8 +9,8 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 KBRANCH = "5.4/yocto"
 KMETA_BRANCH = "yocto-5.4"
 
-LINUX_VERSION ?= "5.4.52"
-SRCREV_machine ?= "81a8ec1567f54b233d4a7383a1f5b10286f76cb7"
+LINUX_VERSION ?= "5.4.46"
+SRCREV_machine ?= "3c038f1968310a1d08245b5f1a550e4e0e06d25d"
 SRCREV_meta ?= "b8c82ba37370e4698ff0c42f3e54b8b4f2fb4ac0"
 
 DEPENDS += "elfutils-native openssl-native util-linux-native"


### PR DESCRIPTION
X11 functionality with 5.4.52 breaks, it require ACRN Hypervisor patch
to support new IDV functionality coming along with 5.4.52.

This reverts commit 3103b51374f86561cf1a676400b1a81845bc4dc9.