### PR TITLE
linux-intel-rt-acrn-uos: fix uos shutdown issue with kernel 5.4

### DIFF
--- a/conf/distro/acrn-demo-uos.conf
+++ b/conf/distro/acrn-demo-uos.conf
@@ -14,6 +14,6 @@ IMAGE_FSTYPES = "wic ext4"
 # configured.
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += "networkd-config"
 
-LINUX_RT_APPEND ?= "${@bb.utils.contains('PREFERRED_PROVIDER_virtual/kernel', 'linux-intel-rt-acrn-uos', 'clocksource=tsc tsc=reliable x2apic_phys processor.max_cstate=0 intel_idle.max_cstate=0 intel_pstate=disable mce=ignore_ce audit=0 isolcpus=nohz,domain,1 nohz_full=1 rcu_nocbs=1 nosoftlockup idle=poll irqaffinity=0', '', d)}"
+LINUX_RT_APPEND ?= "${@bb.utils.contains('PREFERRED_PROVIDER_virtual/kernel', 'linux-intel-rt-acrn-uos', 'clocksource=tsc tsc=reliable x2apic_phys processor.max_cstate=0 intel_idle.max_cstate=0 intel_pstate=disable mce=ignore_ce audit=0 isolcpus=nohz,domain,1 nohz_full=1 rcu_nocbs=1 nosoftlockup idle=poll irqaffinity=0 no_ipi_broadcast=1', '', d)}"
 APPEND += " rw nohpet console=hvc0 console=ttyS0 no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable \
             i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x070F00 ${LINUX_RT_APPEND}"


### PR DESCRIPTION
Linux kernel v5.4 introduces support for IPI shorthand, but ACRN doesn't
it with LAPIC passthroughed for now. So as a workaround, we just disable
this feature to let kernel fall back to the original implementation (send IPI one by one).

BTW, the kernel patchset for IPI shorthand support:
https://lore.kernel.org/lkml/20190722104705.550071814@linutronix.de/

Signed-off-by: Tw <wei.tan@intel.com>