### PR TITLE
acrn-sblimage: add custom image type to inject ACRN SBL boot image

### DIFF
--- a/classes/acrn-sblimage.bbclass
+++ b/classes/acrn-sblimage.bbclass
@@ -1,0 +1,88 @@
+inherit python3native
+DEPENDS += "slimboot-tools-native"
+
+MB_DEPENDENCY    ?= ""
+MB_MC_DEPENDENCY ?= ""
+MB_ACRN_BINARY   ?= "${DEPLOY_DIR_IMAGE}/acrn.32.out"
+MB_ACRN_CMDLINE  ?= ""
+MB_ACRN_MODULES  ?= "${TOPDIR}/conf/linux.txt;${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE}"
+BASE_SBLIMAGE    ?= "sbl_os"
+SBLIMAGE_NAME    ?= "${BASE_SBLIMAGE}"
+PREGENERATED_SIGNING_KEY_SLIMBOOT_KEY_SHA256 ?= "${TOPDIR}/cert/TestSigningPrivateKey.pem"
+
+python do_acrn_sblimage() {
+    import re
+    import os
+    import subprocess
+
+    mbAcrnBinaryDeployDir = d.getVar('MB_ACRN_BINARY').lstrip().rstrip()
+    if not os.path.isfile(mbAcrnBinaryDeployDir):
+        bb.fatal("acrn %s not found!" % mbAcrnBinaryDeployDir)
+
+    mbAcrnCmdlineDeployDir = d.getVar('MB_ACRN_CMDLINE').lstrip().rstrip()
+    if mbAcrnCmdlineDeployDir == "":
+        hv_cmdline = d.getVar('WORKDIR') + "/hv_cmdline"
+        bb.debug(1, "hv_cmdline: %s" % (hv_cmdline))
+        subprocess.check_call("echo 'uart=mmio@0xfe042000' > %s" % (hv_cmdline), shell=True)
+    else:
+        hv_cmdline = mbAcrnCmdlineDeployDir
+
+    mbAcrnBinaryDeployDirPairList = re.split(" +", d.getVar('MB_ACRN_MODULES').lstrip().rstrip())
+
+    genContainerPath = "%s/%s/slimboot/Tools/GenContainer.py" % (d.getVar('STAGING_DIR_NATIVE'), d.getVar('libexecdir'))
+
+    genContainerCmd = "%s" % d.getVar('PYTHON')
+    genContainerCmd = genContainerCmd + " %s create" % (genContainerPath)
+    genContainerCmd = genContainerCmd + " -cl"
+    genContainerCmd = genContainerCmd + " CMDL:%s" % (hv_cmdline)
+    genContainerCmd = genContainerCmd + " ACRN:%s" % (mbAcrnBinaryDeployDir)
+    counter = 0
+    for mbAcrnBinaryDeployDirPair in mbAcrnBinaryDeployDirPairList:
+        mbAcrnBinaryDeployDirPairMods = re.split(";", mbAcrnBinaryDeployDirPair.strip())
+        bb.debug(1, "module[%s]: %s" % (counter,   mbAcrnBinaryDeployDirPairMods[0]))
+        bb.debug(1, "module[%s]: %s" % (counter+1, mbAcrnBinaryDeployDirPairMods[1]))
+
+        if not os.path.isfile(mbAcrnBinaryDeployDirPairMods[0]):
+            bb.fatal("module %s not found!" % mbAcrnBinaryDeployDirPairMods[0])
+
+        if not os.path.isfile(mbAcrnBinaryDeployDirPairMods[1]):
+            bb.fatal("module %s not found!" % mbAcrnBinaryDeployDirPairMods[1])
+
+        genContainerCmd = genContainerCmd + " MOD%s:%s MOD%s:%s" % (counter, mbAcrnBinaryDeployDirPairMods[0], counter+1, mbAcrnBinaryDeployDirPairMods[1])
+        counter = counter + 2
+    genContainerCmd = genContainerCmd + " -o %s/%s" % (d.getVar('WORKDIR'), d.getVar('SBLIMAGE_NAME'))
+    genContainerCmd = genContainerCmd + " -k %s" % (d.getVar('PREGENERATED_SIGNING_KEY_SLIMBOOT_KEY_SHA256'))
+    genContainerCmd = genContainerCmd + " -t MULTIBOOT"
+
+    bb.debug(1, "genContainerCmd: %s" % (genContainerCmd))
+    subprocess.check_call(genContainerCmd, shell=True)
+    subprocess.check_call("install -d %s/boot; install -m 644 %s/%s %s/boot" % (d.getVar('IMAGE_ROOTFS'), d.getVar('WORKDIR'), d.getVar('SBLIMAGE_NAME'), d.getVar('IMAGE_ROOTFS')), shell=True)
+}
+
+python() {
+    import re
+
+    multibootPackageDependencyList = re.split(" +", d.getVar('MB_DEPENDENCY').lstrip().rstrip())
+    multibootPackageMcDependencyList = re.split(" +", d.getVar('MB_MC_DEPENDENCY').lstrip().rstrip())
+
+    bb.debug(1, "Multiboot variable parsing check")
+
+    for multibootPackageDependency in multibootPackageDependencyList:
+        if multibootPackageDependency:
+            dependency = "%s" % (multibootPackageDependency)
+            bb.debug(1, "MultibootDependency: %s" % (dependency))
+            d.appendVarFlag('do_acrn_sblimage', 'depends', ' ' + dependency)
+
+    for multibootPackageMcDependency in multibootPackageMcDependencyList:
+        if multibootPackageMcDependency:
+            mcdependency = "multiconfig::%s" % (multibootPackageMcDependency)
+            bb.debug(1, "MultibootMcDependency: %s" % (mcdependency))
+            d.appendVarFlag('do_acrn_sblimage', 'mcdepends', ' ' + mcdependency)
+
+    # fix host-user-contaminated QA warnings
+    d.setVarFlag('do_acrn_sblimage', 'fakeroot', '1')
+    d.setVarFlag('do_acrn_sblimage', 'umask', '022')
+
+}
+
+addtask do_acrn_sblimage after do_rootfs before do_image

--- a/docs/slimbootloader.md
+++ b/docs/slimbootloader.md
@@ -1,0 +1,102 @@
+# Boot ACRN Hypervisor with Slim Bootloader
+ACRN Hypervisor can boot with Slim Bootloader. This page shows a workflow to generate the multiboot compliant container image to boot ACRN Hypervisor in the hybrid scenario with Slim Bootloader.
+
+### Build Requirements
+* openembedded-core, branch master
+* meta-intel, branch master
+* meta-acrn, branch master
+
+### 1. Setup project
+```
+$ git clone https://git.yoctoproject.org/git/poky
+$ git clone https://git.yoctoproject.org/git/meta-intel
+$ git clone https://git.openembedded.org/meta-openembedded
+$ git clone https://github.com/intel/meta-acrn.git
+$ source poky/oe-init-build-env
+build $ bitbake-layers add-layer \
+../meta-intel \
+../meta-acrn \
+../meta-openembedded/meta-oe
+```
+
+### 2. Configure local conf
+```
+build $ echo "MACHINE = \"intel-corei7-64\"" >> conf/local.conf
+build $ echo "BBMULTICONFIG = \"sos\"" >> conf/local.conf
+```
+
+### 3. Create SOS config file as below
+```
+build $ mkdir conf/multiconfig
+build $ cat conf/multiconfig/sos.conf
+TMPDIR = "${TOPDIR}/master-acrn-sos"
+DISTRO = "acrn-demo-sos"
+
+PREFERRED_PROVIDER_virtual/kernel = "linux-intel-acrn-sos"
+PREFERRED_VERSION_linux-intel-acrn-sos = "5.4%"
+
+ACRN_BOARD = "ehl-crb-b"
+ACRN_SCENARIO = "hybrid"
+
+IMAGE_CLASSES_append = " acrn-sblimage"
+MB_ACRN_MODULES = "\
+    ${TOPDIR}/conf/zephyr.txt;${TOPDIR}/conf/zephyr.bin \
+    ${TOPDIR}/conf/linux.txt;${TMPDIR}/deploy/images/${MACHINE}/${KERNEL_IMAGETYPE} \
+"
+```
+Appending the acrn-sblimage class will run a bitbake task to generate the container image including the module files specified in the MB_ACRN_MODULES list.
+Note: You should not set acrn-sblimage in loca.conf because it will cause a build error when you build Yocto UOS.
+
+### 4. Create module tag files
+```
+build$ echo Linux_bzImage > conf/linux.txt
+build$ echo Zephyr_RawImage > conf/zephyr.txt
+```
+
+### 5. Copy Zephyr image file to the conf/zephyr.bin
+Please refer to [Using Zephyr as User OS](https://projectacrn.github.io/1.6/tutorials/using_zephyr_as_uos.html) about how to build Zephyr
+
+### 6. Generate SBL sign key file
+```
+build$ python $(SBL_ROOT)/BootloaderCorePkg/Tools/GenerateKeys.py -k cert
+build$ cp cert/OS1_TestKey_Priv_RSA2048.pem cert/TestSigningPrivateKey.pem
+```
+
+Please refer to [SBL Keys Generation](https://slimbootloader.github.io/getting-started/build-host-setup.html#sbl-keys) for the details of SBL tools.
+
+### 7. Build SOS image
+```
+build$ bitbake mc:sos:acrn-image-minimal
+```
+
+### 8. Check the sbl_os container image file has been deployed in the generated wic image
+```
+build$ sudo mount \
+`sudo losetup -f -P --show master-acrn-sos/deploy/images/intel-corei7-64/acrn-image-minimal-intel-corei7-64.wic.acrn`p2 \
+/mnt
+build$ ls /mnt/boot/
+bzImage bzImage-5.4.52-linux-intel-acrn-sos EFI loader sbl_os
+```
+
+### Optional Other Variables
+* MB_DEPENDENCY  
+  Set any tasks you want to run before the acrn_sblimage task start. Normally it is not needed since the acrn_sblimage is scheduled at the very last minute of the SOS image creation.
+
+* MB_MC_DEPENDENCY  
+  Set any tasks of UOS you want to run before the acrn_sblimage task start. Typically, it can be used to wait the UOS Linux kernel build in case you want to add the UOS Linux kernel bzImage to the container image so that it can boot as the pre-launched OS.  
+  ```
+  MB_MC_DEPENDENCY = "\
+      uos:virtual/kernel:do_deply \
+  "
+  ```
+* MB_ACRN_BINARY  
+  Set the path to the ACRN Hypervisor binary file. Normally you don't need to change it from default.
+
+* MB_ACRN_CMDLINE  
+  Set the file path which includes the ACRN Hypervisor command line. 
+
+* BASE_SBLIMAGE  
+  Set the file name of the generated container image. Default is "sbl_os".
+
+* PREGENERATED_SIGNING_KEY_SLIMBOOT_KEY_SHA256  
+  Set the path to the image signing key. Default is "${TOPDIR}/cert/TestSigningPrivateKey.pem"


### PR DESCRIPTION
add the image class to generate the multiboot compliant container
images which stitch ACRN Hypervisor and Operating Systems to boot with
Slim Bootloader.

Usage: Example for the ACRN hybrid scenario

1. setup meta-acrn yocto build environment by following the meta-acrn GSG

meta-intel with commit#180027 is required.
http://git.yoctoproject.org/cgit/cgit.cgi/meta-intel/commit/?id=180027

2. add sos to BBMULTICONFIG in conf/local.conf
BBMULTICONFIG = "sos uos"

3. enable the SBL containerization feature for sos in conf/multiconfig/sos.conf

TMPDIR = "${TOPDIR}/master-acrn-sos"
DISTRO = "acrn-demo-sos"

ACRN_BOARD = "ehl-crb-b"
ACRN_SCENARIO = "hybrid"

IMAGE_CLASSES_append = " acrn-sblimage"

4. specify the module files in conf/multiconfig/sos.conf to be stitched in the container

MB_ACRN_MODULES = "\
${TOPDIR}/conf/zephyr.txt;${TOPDIR}/conf/zephyr.bin \
${TOPDIR}/conf/linux.txt;${TMPDIR}/deploy/images/${MACHINE}/${KERNEL_IMAGETYPE} \
"

5. create module tag files
build$ echo Linux_bzImage > conf/linux.txt
build$ echo Zephyr_RawImage > conf/zephyr.txt

Note: zephyr.bin is supposed to be built outside of yocto

6. generate SBL sign key file
build$ python $(SBL_ROOT)/BootloaderCorePkg/Tools/GenerateKeys.py -k cert
build$ cp cert/OS1_TestKey_Priv_RSA2048.pem cert/TestSigningPrivateKey.pem

ref: https://slimbootloader.github.io/getting-started/build-host-setup.html#sbl-keys

7. build SOS image
build$ bitbake mc:sos:acrn-image-minimal

8. confirm the sbl_os container file has been deployed in the generated wic image

build$ sudo losetup -Pf master-acrn-sos/deploy/images/intel-corei7-64/acrn-image-minimal-intel-corei7-64.wic.acrn
build$ sudo mount /dev/loop0p2 /mnt/
build$ ls /mnt/boot/
bzImage  bzImage-5.4.52-linux-intel-acrn-sos  EFI  loader  sbl_os

Signed-off-by: Schmidt, Michael <michael1.schmidt@intel.com>
Signed-off-by: Nishioka, Toshiki <toshiki.nishioka@intel.com>