### PR TITLE
acrn: update to acrn-2020w33.4-180000p

### DIFF
--- a/recipes-core/acrn/acrn-common.inc
+++ b/recipes-core/acrn/acrn-common.inc
@@ -8,8 +8,8 @@ SRC_URI = "git://github.com/projectacrn/acrn-hypervisor.git;branch=${SRCBRANCH};
 
 # Snapshot tags are of the format:
 # acrn-<year>w<week>.<day>-<timestamp><pass|fail>
-PV = "2.1"
-SRCREV = "6cafb9cf01d7029fd05713c04c9a61883e81358d"
+PV = "2.2"
+SRCREV = "b04fba2db53b3cfd133f17aa8fc2312c14be0f2e"
 SRCBRANCH = "master"
 
 UPSTREAM_CHECK_GITTAGREGEX = "^v(?P<pver>\d+(\.\d+)+)$"

--- a/recipes-core/acrn/acrn-hypervisor/hypervisor-dont-build-pre_build.patch
+++ b/recipes-core/acrn/acrn-hypervisor/hypervisor-dont-build-pre_build.patch
@@ -1,0 +1,34 @@
+From e6bdce0651cda22f8186471a89a781c017fd06c2 Mon Sep 17 00:00:00 2001
+From: Lee Chee Yang <chee.yang.lee@intel.com>
+Date: Thu, 6 Aug 2020 10:49:00 +0800
+Subject: [PATCH] hypervisor: dont build pre_build
+
+Execute pre_build_check during hypervisor build is causing error :
+
+| make: /data/yocto/poky/build-acrn/master-acrn-sos/work/intel_corei7_64-oe-linux/acrn-hypervisor/2.1-r0/build//hypervisor/hv_prebuild_check.out: Command not found
+
+It is not build as native tools so it cant be execute during build.
+Hence, dont build it during hypervisor build.
+
+Upstream-Status: Inappropriate
+
+Signed-off-by: Lee Chee Yang <chee.yang.lee@intel.com>
+---
+ hypervisor/Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/hypervisor/Makefile b/hypervisor/Makefile
+index 625cb9a6..25d31702 100644
+--- a/hypervisor/Makefile
++++ b/hypervisor/Makefile
+@@ -379,7 +379,7 @@ VERSION := $(HV_OBJDIR)/include/version.h
+ PRE_BUILD_DIR := ../misc/hv_prebuild
+
+ .PHONY: all
+-all: pre_build $(HV_OBJDIR)/$(HV_FILE).32.out $(HV_OBJDIR)/$(HV_FILE).bin
++all: $(HV_OBJDIR)/$(HV_FILE).32.out $(HV_OBJDIR)/$(HV_FILE).bin
+
+ install: $(HV_OBJDIR)/$(HV_FILE).32.out
+ 	install -D $(HV_OBJDIR)/$(HV_FILE).32.out $(DESTDIR)$(libdir)/acrn/$(HV_FILE).$(BOARD).$(FIRMWARE).$(SCENARIO).32.out
+--
+2.25.1


### PR DESCRIPTION
Commit b5dfe36 added build for hv_prebuild(hv_prebuild_check)
before hypervisor build.

Execute hv_prebuild_check during hypervisor build can cause error :

| make:
/poky/build-acrn/master-acrn-sos/work/intel_corei7_64-oe-linux/acrn-hypervisor/2.1-r0/build//hypervisor/hv_prebuild_check.out:
Command not found

This is due to a hv_prebuild_check binaries build for target and execute
as native during the hypervisor make process.

The hv_prebuild_check binaries need to build as native tools so it could
execute during build, hence dont build it during hypervisor build while
make it as saperate native tools.

Signed-off-by: Chee Yang Lee <chee.yang.lee@intel.com>