### PR TITLE
acrn-hypervisor: always deploy acrn.32.out

### DIFF
--- a/recipes-core/acrn/acrn-hypervisor.bb
+++ b/recipes-core/acrn/acrn-hypervisor.bb
@@ -44,6 +44,9 @@ FILES_${PN}-dbg += "${libdir}/acrn/*.efi.*"
 
 addtask deploy after do_install before do_build
 do_deploy() {
+	install -m 0755 ${D}${libdir}/acrn/acrn.${ACRN_BOARD}.${ACRN_FIRMWARE}.${ACRN_SCENARIO}.32.out ${DEPLOYDIR}
+	rm -f ${DEPLOYDIR}/acrn.32.out
+	lnr ${DEPLOYDIR}/acrn.${ACRN_BOARD}.${ACRN_FIRMWARE}.${ACRN_SCENARIO}.32.out ${DEPLOYDIR}/acrn.32.out
 	if [ "${ACRN_FIRMWARE}" = "uefi" ]; then
 		install -m 0755 ${D}${libdir}/acrn/acrn.${ACRN_BOARD}.${ACRN_SCENARIO}.efi ${DEPLOYDIR}
 		rm -f ${DEPLOYDIR}/acrn.efi


### PR DESCRIPTION
Signed-off-by: Chee Yang Lee <chee.yang.lee@intel.com>