### PR TITLE
linux-intel/4.19: remove patch inherit from linux-intel.inc

### DIFF
--- a/recipes-kernel/linux/linux-intel-acrn_4.19.inc
+++ b/recipes-kernel/linux/linux-intel-acrn_4.19.inc
@@ -6,6 +6,9 @@ SRC_URI_append = "  file://perf-fix-build-with-binutils.patch \
                     file://0001-menuconfig-mconf-cfg-Allow-specification-of-ncurses-.patch \
 "
 
+# This patch in meta-intel linux-intel.inc does not compatible with 4.19 kernel
+SRC_URI_remove = "file://libtraceevent-fix-build-with-binutils-25.patch"
+
 KBRANCH = "4.19/base"
 KMETA_BRANCH = "yocto-4.19"
 

--- a/recipes-kernel/linux/linux-intel-rt-acrn-uos_4.19.bb
+++ b/recipes-kernel/linux/linux-intel-rt-acrn-uos_4.19.bb
@@ -14,6 +14,9 @@ SRC_URI_append = "  file://perf-fix-build-with-binutils.patch \
                     file://uos_rt_4.19.scc \
 "
 
+# this patch in meta-intel linux-intel.inc does not compatible with 4.19 kernel
+SRC_URI_remove = "file://libtraceevent-fix-build-with-binutils-25.patch"
+
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
 KBRANCH = "4.19/preempt-rt"


### PR DESCRIPTION
Patch file added in meta-intel linux-intel.inc in commit
"9fe38203 linux-intel: backport commit to fix perf builds"
does not compatible with 4.19 kernel and caused build error.
Hence drop it from 4.19 kernel.

Error:
| DEBUG: Executing python function extend_recipe_sysroot
| NOTE: Direct dependencies are ['mc:uos:/2TB/yocto/poky-master/meta/recipes-devtools/quilt/quilt-native_0.66.bb:do_populate_sysroot', 'mc:uos:/2TB/yocto/poky-master/meta/recipes-kernel/kern-tools/kern-tools-native_git.bb:do_populate_sysroot', 'mc:uos:virtual:native:/2TB/yocto/poky-master/meta/recipes-devtools/patch/patch_2.7.6.bb:do_populate_sysroot']
| NOTE: Installed into sysroot: []
| NOTE: Skipping as already exists in sysroot: ['quilt-native', 'kern-tools-native', 'patch-native', 'libtool-native', 'attr-native', 'autoconf-native', 'automake-native', 'gnu-config-native', 'texinfo-dummy-native', 'gettext-minimal-native', 'm4-native']
| DEBUG: Python function extend_recipe_sysroot finished
| DEBUG: Executing shell function do_patch
| (1/3) libtraceevent-fix-build-with-binutils-25.patch
| [INFO]: check of .kernel-meta//patches//./libtraceevent-fix-build-with-binutils-25.patch with "git am" did not pass, trying reduced context.
| [INFO]: Context reduced git-am of .kernel-meta//patches//./libtraceevent-fix-build-with-binutils-25.patch with "git am" did not work, trying "apply".
| error: tools/lib/traceevent/plugins/Makefile: does not exist in index
| [ERROR]: Application of .kernel-meta//patches//./libtraceevent-fix-build-with-binutils-25.patch failed.
|          Patch needs to be refreshed. Sample resolution script:
|              .git/rebase-apply/resolve_rejects
| ERROR: Could not apply patches for intel-corei7-64.
| ERROR: Patch failures can be resolved in the linux source directory /2TB/yocto/poky-master/build-acrn/master-acrn-uos/work-shared/intel-corei7-64/kernel-source)
| WARNING: exit code 1 from a shell command.
| ERROR: Execution of '/2TB/yocto/poky-master/build-acrn/master-acrn-uos/work/intel_corei7_64-oe-linux/linux-intel-rt-acrn-uos/4.19.130+gitAUTOINC+da9dc60f73_f7a7451e9e-r0/temp/run.do_patch.1090341' failed with exit code 1:
| (1/3) libtraceevent-fix-build-with-binutils-25.patch
| [INFO]: check of .kernel-meta//patches//./libtraceevent-fix-build-with-binutils-25.patch with "git am" did not pass, trying reduced context.
| [INFO]: Context reduced git-am of .kernel-meta//patches//./libtraceevent-fix-build-with-binutils-25.patch with "git am" did not work, trying "apply".
| error: tools/lib/traceevent/plugins/Makefile: does not exist in index
| [ERROR]: Application of .kernel-meta//patches//./libtraceevent-fix-build-with-binutils-25.patch failed.
|          Patch needs to be refreshed. Sample resolution script:
|              .git/rebase-apply/resolve_rejects
| WARNING: exit code 1 from a shell command.

Signed-off-by: Lee Chee Yang <chee.yang.lee@intel.com>