### PR TITLE
ACRN use gtv-d currently

### DIFF
--- a/recipes-kernel/linux/files/sos.cfg
+++ b/recipes-kernel/linux/files/sos.cfg
@@ -35,3 +35,5 @@ CONFIG_SERIAL_8250_DETECT_IRQ=y
 
 # Let SOS kernel start from higher address to avoid its memory conflict with grub modules
 CONFIG_PHYSICAL_START=0x8000000
+CONFIG_IOMMU_SUPPORT=n
+CONFIG_INTEL_IOMMU=n


### PR DESCRIPTION
ACRN doesn't has vIOMMU feature. So we need to disable IOMMU in SOS kernel to prevent SOS kernel trying to initialize IOMMU. Otherwise, SOS IOMMU access could conflict with HV IOMMU operations and make system hang
Signed-off-by: wenlingz <wenling.zhang@intel.com>