### PR TITLE
acrn-hypervisor: industry as default scenario

### DIFF
--- a/recipes-core/acrn/acrn-hypervisor.bb
+++ b/recipes-core/acrn/acrn-hypervisor.bb
@@ -2,7 +2,7 @@ require acrn-common.inc
 
 ACRN_BOARD ?= "nuc7i7dnb"
 ACRN_FIRMWARE ?= "uefi"
-ACRN_SCENARIO  ?= "sdc"
+ACRN_SCENARIO  ?= "industry"
 
 EXTRA_OEMAKE += "HV_OBJDIR=${B}/hypervisor EFI_OBJDIR=${B}/efi-stub"
 EXTRA_OEMAKE += "BOARD=${ACRN_BOARD} FIRMWARE=${ACRN_FIRMWARE} SCENARIO=${ACRN_SCENARIO}"


### PR DESCRIPTION
Align default SCENARIO (ACRN_SCENARIO) with upstream acrn-hypervisor.

Signed-off-by: Chee Yang Lee <chee.yang.lee@intel.com>