### PR TITLE
linux-intel-ese-lts: add recipes

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -16,4 +16,7 @@ LAYERSERIES_COMPAT_meta-acrn = "zeus dunfell"
 BBFILES_DYNAMIC += " \
     virtualization-layer:${LAYERDIR}/dynamic-layers/virtualization-layer/*/*/*.bb \
     virtualization-layer:${LAYERDIR}/dynamic-layers/virtualization-layer/*/*/*.bbappend \
+    intel-ese-bsp:${LAYERDIR}/dynamic-layers/intel-ese-bsp/*/*/*.bb \
+    intel-ese-bsp:${LAYERDIR}/dynamic-layers/intel-ese-bsp/*/*/*.bbappend \
 "
+LAYERDIR-acrn := "${LAYERDIR}"

--- a/dynamic-layers/intel-ese-bsp/recipes-kernel/linux/linux-intel-ese-acrn.inc
+++ b/dynamic-layers/intel-ese-bsp/recipes-kernel/linux/linux-intel-ese-acrn.inc
@@ -1,0 +1,13 @@
+require recipes-kernel/linux/linux-intel-ese-lts-5.4_git.bb
+
+FILESEXTRAPATHS_prepend := "${LAYERDIR-ese-bsp}/recipes-kernel/linux/linux-config:${LAYERDIR-ese-bsp}/recipes-kernel/linux/files:${LAYERDIR-acrn}/recipes-kernel/linux/files:"
+
+KERNEL_SRC_URI = "git://github.com/intel/linux-intel-lts.git;protocol=https;branch=5.4/yocto;name=machine"
+
+
+SRCREV_machine = "eeb611e5394c56d45c5cc8f7dc484c9f19e93143"
+LINUX_VERSION = "5.4"
+
+KERNEL_PACKAGE_NAME = "kernel"
+KERNEL_VERSION_SANITY_SKIP = "1"
+KCONF_BSP_AUDIT_LEVEL = "0"

--- a/dynamic-layers/intel-ese-bsp/recipes-kernel/linux/linux-intel-ese-lts-acrn-sos_5.4.bb
+++ b/dynamic-layers/intel-ese-bsp/recipes-kernel/linux/linux-intel-ese-lts-acrn-sos_5.4.bb
@@ -1,0 +1,7 @@
+require linux-intel-ese-acrn.inc
+
+SRC_URI_append = "  file://sos_5.4.scc"
+
+LINUX_VERSION_EXTENSION = "-linux-intel-ese-lts-acrn-sos"
+
+SUMMARY = "Linux Intel ESE Kernel with ACRN enabled (SOS)"

--- a/dynamic-layers/intel-ese-bsp/recipes-kernel/linux/linux-intel-ese-lts-acrn-uos_5.4.bb
+++ b/dynamic-layers/intel-ese-bsp/recipes-kernel/linux/linux-intel-ese-lts-acrn-uos_5.4.bb
@@ -1,0 +1,7 @@
+require linux-intel-ese-acrn.inc
+
+SRC_URI_append = "  file://uos_5.4.scc"
+
+LINUX_VERSION_EXTENSION = "-linux-intel-ese-lts-acrn-uos"
+
+SUMMARY = "Linux Intel ESE Kernel with ACRN enabled (UOS)"

--- a/dynamic-layers/intel-ese-bsp/recipes-kernel/linux/linux-intel-ese-lts-rt-acrn-uos_5.4.bb
+++ b/dynamic-layers/intel-ese-bsp/recipes-kernel/linux/linux-intel-ese-lts-rt-acrn-uos_5.4.bb
@@ -1,0 +1,19 @@
+require recipes-kernel/linux/linux-intel-ese-lts-rt-5.4_git.bb
+
+FILESEXTRAPATHS_prepend := "${LAYERDIR-ese-bsp}/recipes-kernel/linux/linux-config:${LAYERDIR-ese-bsp}/recipes-kernel/linux/files:${LAYERDIR-acrn}/recipes-kernel/linux/files:"
+
+KERNEL_SRC_URI = "git://github.com/intel/linux-intel-lts.git;protocol=https;branch=5.4/preempt-rt;name=machine"
+
+SRCREV_machine = "b1e8892a4975fe4f6b5d6e512cd9f4d344fd6d94"
+
+LINUX_VERSION = "5.4"
+
+SRC_URI_append = "  file://uos_rt_5.4.scc"
+
+LINUX_VERSION_EXTENSION = "-linux-intel-ese-lts-preempt-rt-acrn-uos"
+
+SUMMARY = "Linux Intel ESE Preempt RT Kernel with ACRN enabled (UOS)"
+
+KERNEL_PACKAGE_NAME = "kernel"
+KERNEL_VERSION_SANITY_SKIP = "1"
+KCONF_BSP_AUDIT_LEVEL = "0"


### PR DESCRIPTION
These recipes provide support to build linux-intel-ese-lts
and linux-intel-ese-lts-rt kernel from iotg-yocto-ese-bsp layer.

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>