### PR TITLE
acrn-hyperviosr: update to include feature which generate ACPI table …

### DIFF
--- a/recipes-core/acrn/acrn-common.inc
+++ b/recipes-core/acrn/acrn-common.inc
@@ -9,7 +9,7 @@ SRC_URI = "git://github.com/projectacrn/acrn-hypervisor.git;branch=${SRCBRANCH};
 # Snapshot tags are of the format:
 # acrn-<year>w<week>.<day>-<timestamp><pass|fail>
 PV = "2.2"
-SRCREV = "c2d85b13d6e0fa8d1010d03b402300682413ca54"
+SRCREV = "8b86714af8ccf3fb1b313428c5bc88d9977524f9"
 SRCBRANCH = "master"
 
 UPSTREAM_CHECK_GITTAGREGEX = "^v(?P<pver>\d+(\.\d+)+)$"

--- a/recipes-core/acrn/acrn-hypervisor.bb
+++ b/recipes-core/acrn/acrn-hypervisor.bb
@@ -8,13 +8,13 @@ EXTRA_OEMAKE += "HV_OBJDIR=${B}/hypervisor EFI_OBJDIR=${B}/efi-stub"
 EXTRA_OEMAKE += "BOARD=${ACRN_BOARD} FIRMWARE=${ACRN_FIRMWARE} SCENARIO=${ACRN_SCENARIO}"
 EXTRA_OEMAKE += "BOARD_FILE=${S}/misc/acrn-config/xmls/board-xmls/${ACRN_BOARD}.xml SCENARIO_FILE=${S}/misc/acrn-config/xmls/config-xmls/${ACRN_BOARD}/${ACRN_SCENARIO}.xml"
 
-SRC_URI += "file://hypervisor-dont-build-pre_build.patch"
+SRC_URI_append_class-target += "file://hypervisor-dont-build-pre_build.patch"
 
 inherit python3native deploy
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
-DEPENDS += "python3-kconfiglib-native acrn-hypervisor-native"
+DEPENDS += "python3-kconfiglib-native acrn-hypervisor-native acpica-native"
 DEPENDS += "${@'gnu-efi' if d.getVar('ACRN_FIRMWARE') == 'uefi' else ''}"
 
 # parallel build could face build failure in case of config-tool method:
@@ -55,6 +55,10 @@ do_deploy() {
 		install -m 0755 ${D}${libdir}/acrn/acrn.${ACRN_BOARD}.${ACRN_SCENARIO}.efi ${DEPLOYDIR}
 		rm -f ${DEPLOYDIR}/acrn.efi
 		lnr ${DEPLOYDIR}/acrn.${ACRN_BOARD}.${ACRN_SCENARIO}.efi ${DEPLOYDIR}/acrn.efi
+	fi
+	rm -f ${DEPLOYDIR}/ACPI_*.bin
+	if [ -x ${D}${libdir}/acrn/acpi ]; then
+		install -m 0755 ${D}${libdir}/acrn/acpi/ACPI_*.bin ${DEPLOYDIR}
 	fi
 }
 

--- a/recipes-core/acrn/acrn-hypervisor/hypervisor-dont-build-pre_build.patch
+++ b/recipes-core/acrn/acrn-hypervisor/hypervisor-dont-build-pre_build.patch
@@ -1,34 +1,35 @@
-From e6bdce0651cda22f8186471a89a781c017fd06c2 Mon Sep 17 00:00:00 2001
-From: Lee Chee Yang <chee.yang.lee@intel.com>
-Date: Thu, 6 Aug 2020 10:49:00 +0800
-Subject: [PATCH] hypervisor: dont build pre_build
+From 29939f8e4c06bf8a1c5d32b95fce367e245d3508 Mon Sep 17 00:00:00 2001
+From: Naveen Saini <naveen.kumar.saini@intel.com>
+Date: Tue, 8 Sep 2020 13:24:03 +0800
+Subject: [PATCH] hypervisor: dont build pre_build for target
 
 Execute pre_build_check during hypervisor build is causing error :
 
 | make: /data/yocto/poky/build-acrn/master-acrn-sos/work/intel_corei7_64-oe-linux/acrn-hypervisor/2.1-r0/build//hypervisor/hv_prebuild_check.out: Command not found
 
-It is not build as native tools so it cant be execute during build.
-Hence, dont build it during hypervisor build.
+Build and execute as native.
 
 Upstream-Status: Inappropriate
 
-Signed-off-by: Lee Chee Yang <chee.yang.lee@intel.com>
+Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>
 ---
- hypervisor/Makefile | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
+ hypervisor/Makefile | 3 ---
+ 1 file changed, 3 deletions(-)
 
 diff --git a/hypervisor/Makefile b/hypervisor/Makefile
-index 625cb9a6..25d31702 100644
+index e28dc63d..19c3d36e 100644
 --- a/hypervisor/Makefile
 +++ b/hypervisor/Makefile
-@@ -379,7 +379,7 @@ VERSION := $(HV_OBJDIR)/include/version.h
- PRE_BUILD_DIR := ../misc/hv_prebuild
+@@ -395,9 +395,6 @@ install-debug: $(HV_OBJDIR)/$(HV_FILE).map $(HV_OBJDIR)/$(HV_FILE).out
+ 
+ .PHONY: pre_build
+ pre_build: $(HV_OBJDIR)/$(HV_CONFIG_H)
+-	@echo "Start pre-build static check ..."
+-	$(MAKE) -C $(PRE_BUILD_DIR) BOARD=$(BOARD) SCENARIO=$(SCENARIO) TARGET_DIR=$(TARGET_DIR)
+-	@$(HV_OBJDIR)/hv_prebuild_check.out
+ 	@echo "generate the binary of ACPI tables for pre-launched VMs ..."
+ 	python3 ../misc/acrn-config/acpi_gen/bin_gen.py --board $(BOARD) --scenario $(SCENARIO) --asl $(TARGET_DIR) --out $(HV_OBJDIR)/acpi
+ 
+-- 
+2.17.1
 
- .PHONY: all
--all: pre_build $(HV_OBJDIR)/$(HV_FILE).32.out $(HV_OBJDIR)/$(HV_FILE).bin
-+all: $(HV_OBJDIR)/$(HV_FILE).32.out $(HV_OBJDIR)/$(HV_FILE).bin
-
- install: $(HV_OBJDIR)/$(HV_FILE).32.out
- 	install -D $(HV_OBJDIR)/$(HV_FILE).32.out $(DESTDIR)$(libdir)/acrn/$(HV_FILE).$(BOARD).$(FIRMWARE).$(SCENARIO).32.out
---
-2.25.1


### PR DESCRIPTION
…binary

Allow to use offline tool to generate one binary of ACPI tables
for pre-launched VMs.

Below commits are included in this update:

HV: fix uart hang issue caused by bdf overridden
acrn-config: enable TPM2 config on ehl-crb-b board
config: EHL passthough network to pre-launched VM for hybrid_rt
acrn-config: add MACROs for mmcfg bus number
acrn-config: add MACROs for mmcfg bus number
pci: mcfg: limit device bus numbers which could access by ECAM
makefile: compile ACPI tables for pre-launched VMs to one binary
acrn-config: add TPM2 config for pre-launched VMs
acrn-config: offline tool to generate ACPI tables for pre-launched VMs
HV: remove deprecated vacpi build method
HV: add acpi module support for pre-launched VM
HV: refine get multiboot module API
HV: add e820 ACPI entry for pre-launched VM
acrn-config: add swiotlb to sos kernel bootargs to increase bounce bufs
acrn-config: fix the issue of failure to create a new launch setting.
acrn-manager: build and install 'acrnctl' (release and debug)
acrn-config: add hybrid_rt_fusa scenario for fusa related passthru test
HV: Fix SR-IOV problem on EHL
acrn-config: fix csme passthrough issue for launch setting
HV: set CONFIG_HV_RAM_START as min addr when RELOC enabled
acrn-config: update the size range of ivshmem memory region
hv: add vgpio device model support
acrn-config: refine p2sb mmio pass-thru macro definitions
hv: add INTx mapping for pre-launched VMs
hv: support PIO access to platform hidden devices

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>