### PR TITLE
acrn-hypervisor: update to include vm configuration check feature

### DIFF
--- a/recipes-core/acrn/acrn-common.inc
+++ b/recipes-core/acrn/acrn-common.inc
@@ -9,7 +9,7 @@ SRC_URI = "git://github.com/projectacrn/acrn-hypervisor.git;branch=${SRCBRANCH} 
 # Snapshot tags are of the format:
 # acrn-<year>w<week>.<day>-<timestamp><pass|fail>
 PV = "2.1"
-SRCREV = "70e70fa3167888a5d95c235354462f23aa748c7e"
+SRCREV = "50629f682df6dfeeba9d30ef1148ac49703b996a"
 SRCBRANCH = "release_2.1"
 
 UPSTREAM_CHECK_GITTAGREGEX = "^v(?P<pver>\d+(\.\d+)+)$"

--- a/recipes-core/acrn/acrn-hypervisor.bb
+++ b/recipes-core/acrn/acrn-hypervisor.bb
@@ -8,25 +8,29 @@ EXTRA_OEMAKE += "HV_OBJDIR=${B}/hypervisor EFI_OBJDIR=${B}/efi-stub"
 EXTRA_OEMAKE += "BOARD=${ACRN_BOARD} FIRMWARE=${ACRN_FIRMWARE} SCENARIO=${ACRN_SCENARIO}"
 EXTRA_OEMAKE += "BOARD_FILE=${S}/misc/acrn-config/xmls/board-xmls/${ACRN_BOARD}.xml SCENARIO_FILE=${S}/misc/acrn-config/xmls/config-xmls/${ACRN_BOARD}/${ACRN_SCENARIO}.xml"
 
+SRC_URI += "file://hypervisor-dont-build-pre_build.patch"
+
 inherit python3native deploy
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
-DEPENDS += "python3-kconfiglib-native"
+DEPENDS += "python3-kconfiglib-native acrn-hypervisor-native"
 DEPENDS += "${@'gnu-efi' if d.getVar('ACRN_FIRMWARE') == 'uefi' else ''}"
 
 # parallel build could face build failure in case of config-tool method:
 #    | .config does not exist and no defconfig available for BOARD...
 PARALLEL_MAKE = ""
 
-do_compile() {
+do_compile_class-target() {
+	# Execute natively build sanity check for ACRN configurations
+	hv_prebuild_check.out
 	oe_runmake -C hypervisor
 	if [ "${ACRN_FIRMWARE}" = "uefi" ]; then
 		oe_runmake -C misc/efi-stub
 	fi
 }
 
-do_install() {
+do_install_class-target() {
 	oe_runmake -C hypervisor install install-debug
 	if [ "${ACRN_FIRMWARE}" = "uefi" ]; then
 		oe_runmake -C misc/efi-stub install install-debug
@@ -58,3 +62,19 @@ do_deploy() {
 # Stripping is already done by source while building.
 # So 'arch' and 'already-stripped' QA checks can be skipped.
 INSANE_SKIP_${PN} += "arch already-stripped"
+
+do_compile_class-native() {
+	oe_runmake -C hypervisor pre_build
+}
+
+do_install_class-native(){
+	install -d ${D}/${bindir}
+	install -m 755 ${B}/hypervisor/hv_prebuild_check.out ${D}/${bindir}/hv_prebuild_check.out
+}
+
+# no action required for native to deploy
+do_deploy_class-native(){
+	:
+}
+
+BBCLASSEXTEND = "native "

--- a/recipes-core/acrn/acrn-hypervisor/hypervisor-dont-build-pre_build.patch
+++ b/recipes-core/acrn/acrn-hypervisor/hypervisor-dont-build-pre_build.patch
@@ -1,0 +1,34 @@
+From e6bdce0651cda22f8186471a89a781c017fd06c2 Mon Sep 17 00:00:00 2001
+From: Lee Chee Yang <chee.yang.lee@intel.com>
+Date: Thu, 6 Aug 2020 10:49:00 +0800
+Subject: [PATCH] hypervisor: dont build pre_build
+
+Execute pre_build_check during hypervisor build is causing error :
+
+| make: /data/yocto/poky/build-acrn/master-acrn-sos/work/intel_corei7_64-oe-linux/acrn-hypervisor/2.1-r0/build//hypervisor/hv_prebuild_check.out: Command not found
+
+It is not build as native tools so it cant be execute during build.
+Hence, dont build it during hypervisor build.
+
+Upstream-Status: Inappropriate
+
+Signed-off-by: Lee Chee Yang <chee.yang.lee@intel.com>
+---
+ hypervisor/Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/hypervisor/Makefile b/hypervisor/Makefile
+index 625cb9a6..25d31702 100644
+--- a/hypervisor/Makefile
++++ b/hypervisor/Makefile
+@@ -379,7 +379,7 @@ VERSION := $(HV_OBJDIR)/include/version.h
+ PRE_BUILD_DIR := ../misc/hv_prebuild
+
+ .PHONY: all
+-all: pre_build $(HV_OBJDIR)/$(HV_FILE).32.out $(HV_OBJDIR)/$(HV_FILE).bin
++all: $(HV_OBJDIR)/$(HV_FILE).32.out $(HV_OBJDIR)/$(HV_FILE).bin
+
+ install: $(HV_OBJDIR)/$(HV_FILE).32.out
+ 	install -D $(HV_OBJDIR)/$(HV_FILE).32.out $(DESTDIR)$(libdir)/acrn/$(HV_FILE).$(BOARD).$(FIRMWARE).$(SCENARIO).32.out
+--
+2.25.1


### PR DESCRIPTION
Commit b5dfe36 added build for hv_prebuild(pre_build_check)
before hypervisor build.

Execute pre_build_check during hypervisor build can cause error :

| make:
/poky/build-acrn/master-acrn-sos/work/intel_corei7_64-oe-linux/acrn-hypervisor/2.1-r0/build//hypervisor/hv_prebuild_check.out:
Command not found

This is due to a pre_build_check binaries build for target and execute
as native during the hypervisor make process.

The pre_build_check binaries need to build as native tools so it could
execute during build, hence dont build it during hypervisor build while
make it as saperate native tools.

Below commits are included in this update.
acrn-config: get the max number with integer list
Makefile: modify the realpath to abspath function
HV: move vm configuration check to pre-build time
HV: remove sanitize_vm_config function
HV: Make: simplify acpi info header file check
acrn-config: Enable pre-launch VM sharing CPU with other VMs
acrn-config: add cpu_affinity for SOS VM
HV: add cpu affinity info for SOS VM
hv: enlarge vuart number from 2 to 4 for each vm

Signed-off-by: Chee Yang Lee <chee.yang.lee@intel.com>
Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>