### PR TITLE
update ACRN:acrn-2020w40.1-180000p release_2.2 RC5

### DIFF
--- a/recipes-core/acrn/acrn-common.inc
+++ b/recipes-core/acrn/acrn-common.inc
@@ -9,7 +9,7 @@ SRC_URI = "git://github.com/projectacrn/acrn-hypervisor.git;branch=${SRCBRANCH};
 # Snapshot tags are of the format:
 # acrn-<year>w<week>.<day>-<timestamp><pass|fail>
 PV = "2.2"
-SRCREV = "de0b588fff015d8e46f0105fe39fc603771f0de2"
+SRCREV = "3b6b5fb6627651dbd3a65e422ed0a6b668916abc"
 SRCBRANCH = "release_2.2"
 
 UPSTREAM_CHECK_GITTAGREGEX = "^v(?P<pver>\d+(\.\d+)+)$"


### PR DESCRIPTION
updated with the ACRN daily tag acrn-2020w40.1-180000p commit id. ACRN release_2.2’s RC5(final code tag)