### PR TITLE
[master-next]acrn: fix trailing slash in S and B

### DIFF
--- a/recipes-core/acrn/acrn-common.inc
+++ b/recipes-core/acrn/acrn-common.inc
@@ -14,7 +14,7 @@ SRCBRANCH = "release_2.2"
 
 UPSTREAM_CHECK_GITTAGREGEX = "^v(?P<pver>\d+(\.\d+)+)$"
 
-S = "${WORKDIR}/git/"
+S = "${WORKDIR}/git"
 
 CVE_PRODUCT = "acrn"
 
@@ -35,7 +35,7 @@ EXTRA_OEMAKE += "RELEASE=${ACRN_RELEASE} \
 
 # acrn supports build objects out-of-tree but builds must be performed from
 # inside the source
-B = "${WORKDIR}/build/"
+B = "${WORKDIR}/build"
 do_configure[cleandirs] = "${B}"
 do_configure[dirs] = "${S}"
 do_compile[dirs] = "${S}"


### PR DESCRIPTION
This fixes warning about a trailing slash on ${S} and ${B}.

Signed-off-by: Chee Yang Lee <chee.yang.lee@intel.com>