### PR TITLE
container-package: drop redundant dependency

### DIFF
--- a/classes/container-package.bbclass
+++ b/classes/container-package.bbclass
@@ -16,7 +16,6 @@ IMAGE_NAME := "${@d.getVar('PN').replace('-package', '')}"
 # Where to install the image
 containerdir ?= "${localstatedir}/lib/machines"
 
-do_install[depends] += "virtual/kernel:do_deploy"
 do_install[mcdepends] += "multiconfig::${CONTAINER_PACKAGE_MC}:${IMAGE_NAME}:do_image_complete"
 
 do_install () {


### PR DESCRIPTION
After switching to wic, dependency on kernel:do_deploy
is redundent and it also creates circular dependencies
for dm-verity build.

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>