### PR TITLE
uos-rt.cfg: Enable TPM CRB for RT kernal

### DIFF
--- a/recipes-kernel/linux/linux-intel-rt-acrn-uos_4.19.bb
+++ b/recipes-kernel/linux/linux-intel-rt-acrn-uos_4.19.bb
@@ -32,6 +32,7 @@ KERNEL_FEATURES_append = "features/netfilter/netfilter.scc \
                           features/security/security.scc  \
                           cfg/hv-guest.scc \
                           cfg/paravirt_kvm.scc \
+                          features/tpm/tpm.scc \
                           features/net/stmicro/stmmac.cfg \
 "
 

--- a/recipes-kernel/linux/linux-intel-rt-acrn-uos_5.4.bb
+++ b/recipes-kernel/linux/linux-intel-rt-acrn-uos_5.4.bb
@@ -32,6 +32,7 @@ KERNEL_FEATURES_append = "features/netfilter/netfilter.scc \
                           features/security/security.scc  \
                           cfg/hv-guest.scc \
                           cfg/paravirt_kvm.scc \
+                          features/tpm/tpm.scc \
                           features/net/stmicro/stmmac.cfg \
 "
 


### PR DESCRIPTION
CONFIG_TCG_CRB is used to enable MSFT0101 TPM. It's needed by a real-time
kernel for security.

Signed-off-by: Li Fei1 <fei1.li@intel.com>