### PR TITLE
acrn-bootdisk-dmverity.wks.in: add wks for dm-verity

### DIFF
--- a/classes/image-acrn.bbclass
+++ b/classes/image-acrn.bbclass
@@ -6,7 +6,10 @@ IMAGE_FSTYPES += "ext4 wic"
 # below example show zephyr.bin as VM0 without bootargs and
 # bzImage as VM1 with bootargs eg :
 # ACRN_EFI_BOOT_CONF ?= "zephyr.bin:Zephyr_RawImage;bzImage:Linux_bzImage:rootwait root=/dev/sda1;"
-ACRN_EFI_BOOT_CONF ?= "${KERNEL_IMAGETYPE}:Linux_bzImage;"
+ACRN_EFI_BOOT_COMMON_CONF ?= "${KERNEL_IMAGETYPE}:Linux_bzImage;"
+ACRN_EFI_BOOT_DMVERITY_CONF ?= "${KERNEL_IMAGETYPE}-${INITRAMFS_LINK_NAME}.bin:Linux_bzImage;"
+
+
+ACRN_EFI_BOOT_CONF ?= "${@bb.utils.contains_any("IMAGE_CLASSES", "dm-verity-img", "${ACRN_EFI_BOOT_DMVERITY_CONF}", "${ACRN_EFI_BOOT_COMMON_CONF}", d)}"
 
 WICVARS_append = " ACRN_EFI_BOOT_CONF IMAGE_EFI_BOOT_FILES "
-

--- a/conf/distro/acrn-demo-sos.conf
+++ b/conf/distro/acrn-demo-sos.conf
@@ -20,4 +20,4 @@ APPEND += "${LINUX_ACRN_APPEND} ${LINUX_GVT_APPEND}"
 
 EFI_PROVIDER = "grub-efi"
 GRUB_BUILDIN_append = " multiboot2 "
-WKS_FILE = "acrn-bootdisk-microcode.wks.in"
+WKS_FILE = "${@bb.utils.contains_any("IMAGE_CLASSES", "dm-verity-img", "acrn-bootdisk-dmverity.wks.in", "acrn-bootdisk-microcode.wks.in", d)}"

--- a/wic/acrn-bootdisk-dmverity.wks.in
+++ b/wic/acrn-bootdisk-dmverity.wks.in
@@ -1,0 +1,10 @@
+# short-description: Create an dm-verity EFI disk image with acrn and grub-efi
+# long-description: Creates a partitioned dm-verity EFI disk image with acrn-hypervisor.
+
+part /boot --source acrn-bootimg-efi --sourceparams="initrd=microcode.cpio" --ondisk sda --active --align 1024 --use-uuid
+
+part / --source rawcopy --ondisk sda  --sourceparams="file=${IMGDEPLOYDIR}/${DM_VERITY_IMAGE}-${MACHINE}.${DM_VERITY_IMAGE_TYPE}.verity" --use-uuid
+
+part swap --ondisk sda --size 44 --label swap1 --fstype=swap --use-uuid
+
+bootloader --ptable gpt --timeout=5 --append=" "


### PR DESCRIPTION
Configure WKS_FILE and ACRN_EFI_BOOT_CONF vars for dm-verity.

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>