### PR TITLE
docs:dm-verity: set ACRN_EFI_BOOT_CONF in .conf

### DIFF
--- a/classes/image-acrn.bbclass
+++ b/classes/image-acrn.bbclass
@@ -6,10 +6,6 @@ IMAGE_FSTYPES += "ext4 wic"
 # below example show zephyr.bin as VM0 without bootargs and
 # bzImage as VM1 with bootargs eg :
 # ACRN_EFI_BOOT_CONF ?= "zephyr.bin:Zephyr_RawImage;bzImage:Linux_bzImage:rootwait root=/dev/sda1;"
-ACRN_EFI_BOOT_COMMON_CONF ?= "${KERNEL_IMAGETYPE}:Linux_bzImage;"
-ACRN_EFI_BOOT_DMVERITY_CONF ?= "${KERNEL_IMAGETYPE}-${INITRAMFS_LINK_NAME}.bin:Linux_bzImage;"
-
-
-ACRN_EFI_BOOT_CONF ?= "${@bb.utils.contains_any("IMAGE_CLASSES", "dm-verity-img", "${ACRN_EFI_BOOT_DMVERITY_CONF}", "${ACRN_EFI_BOOT_COMMON_CONF}", d)}"
+ACRN_EFI_BOOT_CONF ?= "${KERNEL_IMAGETYPE}:Linux_bzImage;"
 
 WICVARS_append = " ACRN_EFI_BOOT_CONF IMAGE_EFI_BOOT_FILES "

--- a/docs/dm-verity.md
+++ b/docs/dm-verity.md
@@ -36,6 +36,9 @@ DM_VERITY_IMAGE_TYPE = "ext4"
 INITRAMFS_IMAGE = "dm-verity-image-initramfs"
 INITRAMFS_FSTYPES = "cpio.gz"
 INITRAMFS_IMAGE_BUNDLE = "1"
+
+# update the ACRN_EFI_BOOT_CONF for the kernel image with initramfs bundled
+ACRN_EFI_BOOT_CONF = "${KERNEL_IMAGETYPE}-${INITRAMFS_LINK_NAME}.bin:Linux_bzImage;"
 ```
 
 conf/local.conf should enable multiconfig build for sos


### PR DESCRIPTION
logic for ACRN_EFI_BOOT_CONF is causing error when do_image_wic.
so set it manually to avoid the error.

| ERROR: unable to parse ACRN_EFI_BOOT_CONF, in "", d)}" exiting

Signed-off-by: Chee Yang Lee <chee.yang.lee@intel.com>