### PR TITLE
linux-intel-ese* use SRCREV from intel-ese-bsp

### DIFF
--- a/dynamic-layers/intel-ese-bsp/recipes-kernel/linux/linux-intel-ese-acrn.inc
+++ b/dynamic-layers/intel-ese-bsp/recipes-kernel/linux/linux-intel-ese-acrn.inc
@@ -2,12 +2,6 @@ require recipes-kernel/linux/linux-intel-ese-lts-5.4_git.bb
 
 FILESEXTRAPATHS_prepend := "${LAYERDIR-ese-bsp}/recipes-kernel/linux/linux-config:${LAYERDIR-ese-bsp}/recipes-kernel/linux/files:${LAYERDIR-acrn}/recipes-kernel/linux/files:"
 
-KERNEL_SRC_URI = "git://github.com/intel/linux-intel-lts.git;protocol=https;branch=5.4/yocto;name=machine"
-
-
-SRCREV_machine = "eeb611e5394c56d45c5cc8f7dc484c9f19e93143"
-LINUX_VERSION = "5.4"
-
 KERNEL_PACKAGE_NAME = "kernel"
 KERNEL_VERSION_SANITY_SKIP = "1"
 KCONF_BSP_AUDIT_LEVEL = "0"

--- a/dynamic-layers/intel-ese-bsp/recipes-kernel/linux/linux-intel-ese-lts-rt-acrn-uos_5.4.bb
+++ b/dynamic-layers/intel-ese-bsp/recipes-kernel/linux/linux-intel-ese-lts-rt-acrn-uos_5.4.bb
@@ -2,12 +2,6 @@ require recipes-kernel/linux/linux-intel-ese-lts-rt-5.4_git.bb
 
 FILESEXTRAPATHS_prepend := "${LAYERDIR-ese-bsp}/recipes-kernel/linux/linux-config:${LAYERDIR-ese-bsp}/recipes-kernel/linux/files:${LAYERDIR-acrn}/recipes-kernel/linux/files:"
 
-KERNEL_SRC_URI = "git://github.com/intel/linux-intel-lts.git;protocol=https;branch=5.4/preempt-rt;name=machine"
-
-SRCREV_machine = "b1e8892a4975fe4f6b5d6e512cd9f4d344fd6d94"
-
-LINUX_VERSION = "5.4"
-
 SRC_URI_append = "  file://uos_rt_5.4.scc"
 
 LINUX_VERSION_EXTENSION = "-linux-intel-ese-lts-preempt-rt-acrn-uos"


### PR DESCRIPTION
linux-intel-ese-lts-acrn-sos
linux-intel-ese-lts-acrn-uos
linux-intel-ese-lts-rt-acrn-uos
to inherit KERNEL_SRC_URI, SRCREV_machine  and  LINUX_VERSION from intel-ese-bsp layer 