### PR TITLE
acrn: update config for ehl-crb-b

### DIFF
--- a/recipes-core/acrn/acrn-common.inc
+++ b/recipes-core/acrn/acrn-common.inc
@@ -9,7 +9,7 @@ SRC_URI = "git://github.com/projectacrn/acrn-hypervisor.git;branch=${SRCBRANCH} 
 # Snapshot tags are of the format:
 # acrn-<year>w<week>.<day>-<timestamp><pass|fail>
 PV = "2.2"
-SRCREV = "be85d092c40db8ccc1bd95457a3f6d08eeaf7403"
+SRCREV = "74e1195077384b9f529fdce4953a49db70b92959"
 SRCBRANCH = "release_2.2"
 
 UPSTREAM_CHECK_GITTAGREGEX = "^v(?P<pver>\d+(\.\d+)+)$"


### PR DESCRIPTION
updates to latest HEAD to catch logical_partition config changes
for ehl-crb-b.

latest HEAD included:
    acrn-config: update logical_partition for ehl-crb-b
    doc: doc fixes post 2.2 release

Signed-off-by: Chee Yang Lee <chee.yang.lee@intel.com>