### PR TITLE
acrn-life-mngr: add recipe

### DIFF
--- a/recipes-core/acrn/acrn-life-mngr.bb
+++ b/recipes-core/acrn/acrn-life-mngr.bb
@@ -1,0 +1,20 @@
+require acrn-common.inc
+
+inherit features_check systemd
+
+REQUIRED_DISTRO_FEATURES = "systemd"
+
+EXTRA_OEMAKE += " OUT_DIR=${B} "
+
+do_compile() {
+	oe_runmake -C misc/life_mngr
+}
+
+do_install() {
+	install -d ${D}${bindir}
+	install -m 0755 ${B}/life_mngr ${D}${bindir}
+	install -d ${D}${systemd_unitdir}/system/
+	install -m 0644 ${B}/life_mngr.service ${D}${systemd_unitdir}/system/
+}
+
+SYSTEMD_SERVICE_${PN} = "life_mngr.service"


### PR DESCRIPTION
Add recipe for User VM "lifecycle manager"
https://projectacrn.github.io/latest/tutorials/enable_s5.html#user-vm-lifecycle-manager

life cycle manager could be installed onto UOS by
adding below line to multiconfig/uos.conf:
IMAGE_INSTALL += " acrn-life-mngr "

Signed-off-by: Lee Chee Yang <chee.yang.lee@intel.com>