### PR TITLE
linux-intel-ese-acrn: add configs

### DIFF
--- a/dynamic-layers/intel-ese-bsp/recipes-kernel/linux/linux-intel-ese-acrn.inc
+++ b/dynamic-layers/intel-ese-bsp/recipes-kernel/linux/linux-intel-ese-acrn.inc
@@ -2,6 +2,11 @@ require recipes-kernel/linux/linux-intel-ese-lts-5.4_git.bb
 
 FILESEXTRAPATHS_prepend := "${LAYERDIR-ese-bsp}/recipes-kernel/linux/linux-config:${LAYERDIR-ese-bsp}/recipes-kernel/linux/files:${LAYERDIR-acrn}/recipes-kernel/linux/files:"
 
+KERNEL_FEATURES_append = "features/netfilter/netfilter.scc \
+                          cfg/hv-guest.scc \
+                          cfg/paravirt_kvm.scc \
+                          "
+
 KERNEL_PACKAGE_NAME = "kernel"
 KERNEL_VERSION_SANITY_SKIP = "1"
 KCONF_BSP_AUDIT_LEVEL = "0"

--- a/dynamic-layers/intel-ese-bsp/recipes-kernel/linux/linux-intel-ese-lts-acrn-sos_5.4.bb
+++ b/dynamic-layers/intel-ese-bsp/recipes-kernel/linux/linux-intel-ese-lts-acrn-sos_5.4.bb
@@ -6,6 +6,10 @@ LINUX_VERSION_EXTENSION = "-linux-intel-ese-lts-acrn-sos"
 
 SUMMARY = "Linux Intel ESE Kernel with ACRN enabled (SOS)"
 
+KERNEL_FEATURES_append = " features/criu/criu-enable.scc \
+                          cgl/cfg/iscsi.scc \
+"
+
 SRC_URI_append = " ${@get_scenario_cfg(d)}"
 
 def get_scenario_cfg(d):

--- a/dynamic-layers/intel-ese-bsp/recipes-kernel/linux/linux-intel-ese-lts-rt-acrn-uos_5.4.bb
+++ b/dynamic-layers/intel-ese-bsp/recipes-kernel/linux/linux-intel-ese-lts-rt-acrn-uos_5.4.bb
@@ -4,6 +4,12 @@ FILESEXTRAPATHS_prepend := "${LAYERDIR-ese-bsp}/recipes-kernel/linux/linux-confi
 
 SRC_URI_append = "  file://uos_rt_5.4.scc"
 
+KERNEL_FEATURES_append = "features/netfilter/netfilter.scc \
+                          cfg/hv-guest.scc \
+                          cfg/paravirt_kvm.scc \
+                          features/net/stmicro/stmmac.cfg \
+"
+
 LINUX_VERSION_EXTENSION = "-linux-intel-ese-lts-preempt-rt-acrn-uos"
 
 SUMMARY = "Linux Intel ESE Preempt RT Kernel with ACRN enabled (UOS)"


### PR DESCRIPTION
Enable OpenStack-related and other ACRN recommended
configs for linux-intel-ese-lts*_5.4 (SOS, UOS and RT UOS) kernels

Ported from linux-intel-acrn-* 5.4 kernel recipes.

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>