### PR TITLE
travis: use dunfell branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ env:
   - DISTRO=acrn-demo-sos
 
 install:
- - git clone --depth=10 --branch=master git://git.yoctoproject.org/meta-intel ../meta-intel
- - git clone --depth=50 --branch=master git://git.yoctoproject.org/poky ../poky
+ - git clone --depth=10 --branch=dunfell git://git.yoctoproject.org/meta-intel ../meta-intel
+ - git clone --depth=50 --branch=dunfell git://git.yoctoproject.org/poky ../poky
  - . ../poky/oe-init-build-env $TRAVIS_BUILD_DIR/build
  - bitbake-layers add-layer ../../meta-intel
  - bitbake-layers add-layer ../../meta-acrn


### PR DESCRIPTION
oe-core master branch no longer compatible with dunfell since commit
d2e0d82f3e34a6c49066e39775572c5b8cd3c392. Hence use dunfell for oe-core
and meta-intel in travis build.

Signed-off-by: Chee Yang Lee <chee.yang.lee@intel.com>