### PR TITLE
acrn-libvirt: fix host gcc can't recognized option -fmacro-prefix-map

### DIFF
--- a/dynamic-layers/virtualization-layer/recipes-extended/libvirt/libvirt-python.inc
+++ b/dynamic-layers/virtualization-layer/recipes-extended/libvirt/libvirt-python.inc
@@ -25,6 +25,11 @@ export LIBVIRT_CFLAGS = "-I${S}/include"
 export LIBVIRT_LIBS = "-L${B}/src/.libs -lvirt -ldl"
 export LDFLAGS="-L${B}/src/.libs"
 
+export LDSHARED  = "${CCLD} -shared"
+export LDCXXSHARED  = "${CXX} -shared"
+export CCSHARED  = "-fPIC -DPIC"
+export LINKFORSHARED = "${SECURITY_CFLAGS} -Xlinker -export-dynamic"
+
 LIBVIRT_INSTALL_ARGS = "--root=${D} \
     --prefix=${prefix} \
     --install-lib=${PYTHON_SITEPACKAGES_DIR} \


### PR DESCRIPTION
libvirt-python picks host gcc (instead of cross gcc) to build shared
library in absense of LD*SHARED flags.

Instead of inherit distutils3-base.class, taking SHARED flags to create
libvirt-python package.

Ref: https://git.yoctoproject.org/cgit/cgit.cgi/poky/tree/meta/classes/distutils-common-base.bbclass

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>