### PR TITLE
doc: document required 'pam' distro_feature for weston images

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -49,11 +49,14 @@ Test that you can build multiconfigs:
 $ bitbake multiconfig:uos:core-image-base
 ```
 
-This should build you a `core-image-base.ext4` in the UOS work directory. Now build your acrn image:
+This should build you a `core-image-base.wic` in the UOS work directory. Now build your acrn image:
 
 ```
 $ bitbake acrn-image-base
 ```
+
+Due to recent changes, you need to add 'pam' to DISTRO_FETARUTES for weston images in local.conf or uos.conf.
+DISTRO_FEATURES_append = " pam"
 
 Note that thanks to a bug in bitbake if you go straight to `acrn-image-base` from an empty sstate then it will build a lot of recipes twice.  For speed, build the UOS image first and then the SOS, as the SOS image can re-use 99% of the sstate.
 


### PR DESCRIPTION
Now 'pam' has become required distro feature for weston package
when systemd is init manager, which cause below acrn build failures:

Build Error:
ERROR: Nothing RPROVIDES 'weston' (but meta-acrn/recipes-core/images/acrn-image-weston.bb RDEPENDS on or otherwise requires it)
ERROR: Nothing RPROVIDES 'weston-init' (but meta-acrn/recipes-core/images/acrn-image-weston.bb RDEPENDS on or otherwise requires it)
ERROR: Nothing RPROVIDES 'weston-examples' (but meta-acrn/recipes-core/images/acrn-image-weston.bb RDEPENDS on or otherwise requires it)
ERROR: Nothing RPROVIDES 'weston-xwayland' (but meta-acrn/recipes-core/images/acrn-image-weston.bb RDEPENDS on or otherwise requires it)
ERROR: Nothing RPROVIDES 'acrn-image-weston'
ERROR: Nothing RPROVIDES 'weston' (but mc:uos:meta/recipes-graphics/images/core-image-weston.bb RDEPENDS on or otherwise requires it)
ERROR: Nothing RPROVIDES 'weston-init' (but mc:uos:meta/recipes-graphics/images/core-image-weston.bb RDEPENDS on or otherwise requires it)
ERROR: Nothing RPROVIDES 'weston-examples' (but mc:uos:meta/recipes-graphics/images/core-image-weston.bb RDEPENDS on or otherwise requires it)
ERROR: Nothing RPROVIDES 'weston-xwayland' (but mc:uos:meta/recipes-graphics/images/core-image-weston.bb RDEPENDS on or otherwise requires it)
ERROR: Nothing RPROVIDES 'core-image-weston'
ERROR: Nothing PROVIDES 'core-image-weston'

Ref: https://git.yoctoproject.org/cgit/cgit.cgi/poky/commit/?id=a51ebb8d2d30436b449aa33b91ba8dd20410002b

Also updated document for UOS wic image.

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>