### PR TITLE
acrn-tools: dont build  life_mngr

### DIFF
--- a/recipes-core/acrn/acrn-tools.bb
+++ b/recipes-core/acrn/acrn-tools.bb
@@ -6,6 +6,7 @@ DEPENDS += "numactl systemd e2fsprogs libevent libxml2 openssl"
 RDEPENDS_${PN} += "bash"
 
 SRC_URI += " file://add-fcommon-to-CFLAGS.patch \
+             file://no-life-mngr.patch \
 "
 
 do_compile() {

--- a/recipes-core/acrn/acrn-tools/no-life-mngr.patch
+++ b/recipes-core/acrn/acrn-tools/no-life-mngr.patch
@@ -1,0 +1,47 @@
+From 500156964cede873a4f83c0c9a74d536f12d646e Mon Sep 17 00:00:00 2001
+From: Lee Chee Yang <chee.yang.lee@intel.com>
+Date: Fri, 19 Jun 2020 16:43:29 +0800
+Subject: [PATCH] no life-mngr
+
+dont build life-mngr in acrn-tools.
+life-mngr daemon is for User VM only. 
+it should be saperate from acrn-tools which for Service VM.
+
+Upstream-Status: Inappropriate
+
+Signed-off-by: Lee Chee Yang <chee.yang.lee@intel.com>
+---
+ misc/Makefile | 9 ++++-----
+ 1 file changed, 4 insertions(+), 5 deletions(-)
+
+diff --git a/misc/Makefile b/misc/Makefile
+index 1a510ad3..a65023ed 100644
+--- a/misc/Makefile
++++ b/misc/Makefile
+@@ -2,9 +2,9 @@ T := $(CURDIR)
+ OUT_DIR ?= $(shell mkdir -p $(T)/build;cd $(T)/build;pwd)
+ RELEASE ?= 0
+
+-.PHONY: all acrn-crashlog acrnlog acrn-manager acrntrace acrnbridge life_mngr
++.PHONY: all acrn-crashlog acrnlog acrn-manager acrntrace acrnbridge 
+ ifeq ($(RELEASE),0)
+-all: acrn-crashlog acrnlog acrn-manager acrntrace acrnbridge life_mngr
++all: acrn-crashlog acrnlog acrn-manager acrntrace acrnbridge 
+ else
+ all: acrn-manager acrnbridge life_mngr
+ endif
+@@ -38,10 +38,9 @@ clean:
+
+ .PHONY: install
+ ifeq ($(RELEASE),0)
+-install: acrn-crashlog-install acrnlog-install acrn-manager-install acrntrace-install acrnbridge-install \
+-	acrn-life-mngr-install
++install: acrn-crashlog-install acrnlog-install acrn-manager-install acrntrace-install acrnbridge-install 
+ else
+-install: acrn-manager-install acrnbridge-install acrn-life-mngr-install
++install: acrn-manager-install acrnbridge-install 
+ endif
+
+ acrn-crashlog-install:
+-- 
+2.25.1


### PR DESCRIPTION
dont build for life_mngr in acrn-tools.
life_mngr is for User VM while other acrn tools for Service VM
so life_mngr should be saperate from acrn-tools recipe.

Signed-off-by: Chee Yang Lee <chee.yang.lee@intel.com>