### PR TITLE
acrn-demo: drop invalid AcrnGT kernel parameters

### DIFF
--- a/conf/distro/acrn-demo-sos.conf
+++ b/conf/distro/acrn-demo-sos.conf
@@ -14,7 +14,7 @@ PREFERRED_PROVIDER_nativesdk-libvirt = "nativesdk-acrn-libvirt"
 # ACRN hypervisor log setting, sensible defaults
 LINUX_ACRN_APPEND ?= "hvlog=2M@0xE00000 ${@bb.utils.contains('EFI_PROVIDER','grub-efi','memmap=2M\$0xE00000','memmap=2M$0xE00000',d)} "
 # GVT enabling. SOS has pipe 0, one UOS has the rest.
-LINUX_GVT_APPEND ?= "i915.enable_gvt=1 i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.domain_scaler_owner=0x011100"
+LINUX_GVT_APPEND ?= "i915.enable_gvt=1 i915.nuclear_pageflip=1 "
 
 APPEND += "${LINUX_ACRN_APPEND} ${LINUX_GVT_APPEND}"
 

--- a/conf/distro/acrn-demo-uos.conf
+++ b/conf/distro/acrn-demo-uos.conf
@@ -16,4 +16,4 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += "networkd-config"
 
 LINUX_RT_APPEND ?= "${@bb.utils.contains('PREFERRED_PROVIDER_virtual/kernel', 'linux-intel-rt-acrn-uos', 'clocksource=tsc tsc=reliable x2apic_phys processor.max_cstate=0 intel_idle.max_cstate=0 intel_pstate=disable mce=ignore_ce audit=0 isolcpus=nohz,domain,1 nohz_full=1 rcu_nocbs=1 nosoftlockup idle=poll irqaffinity=0 no_ipi_broadcast=1', '', d)}"
 APPEND += " rw nohpet console=hvc0 console=ttyS0 no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable \
-            i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x070F00 ${LINUX_RT_APPEND}"
+            i915.nuclear_pageflip=1 ${LINUX_RT_APPEND}"


### PR DESCRIPTION
Drop invalid GVT-g kernel options which are not
valid anymore from ACRN 2.0 and higher.

Dropping i915.domain_scaler_owner option as well
for SOS.

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>