### PR TITLE
acrn-demo-sos.conf: weak assign WKS_FILE

### DIFF
--- a/conf/distro/acrn-demo-sos.conf
+++ b/conf/distro/acrn-demo-sos.conf
@@ -20,4 +20,4 @@ APPEND += "${LINUX_ACRN_APPEND} ${LINUX_GVT_APPEND}"
 
 EFI_PROVIDER = "grub-efi"
 GRUB_BUILDIN_append = " multiboot2 "
-WKS_FILE = "${@bb.utils.contains_any("IMAGE_CLASSES", "dm-verity-img", "acrn-bootdisk-dmverity.wks.in", "acrn-bootdisk-microcode.wks.in", d)}"
+WKS_FILE ??= "${@bb.utils.contains_any("IMAGE_CLASSES", "dm-verity-img", "acrn-bootdisk-dmverity.wks.in", "acrn-bootdisk-microcode.wks.in", d)}"


### PR DESCRIPTION
Issue:
WKS_FILE is assigned in this DISTRO configuration, which
is being parsed after local.conf. Therefore, any WKS_FILE
that is set in local.conf is being overridden.

Fix:
Change assignment from = to ??=

Signed-off-by: mitchdz <mitch_dz@hotmail.com>