### PR TITLE
acrn: upgrade v2.3 -> v2.4

### DIFF
--- a/recipes-core/acrn/acrn-common.inc
+++ b/recipes-core/acrn/acrn-common.inc
@@ -1,15 +1,15 @@
 SUMMARY = "A Type 1 hypervisor stack, running directly on the bare-metal hardware"
 HOMEPAGE = "https://projectacrn.org/"
 LICENSE = "BSD-3-Clause"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=5732af37bf18525ed9d2b16985054901"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=b762ef53db85c389256a9d215053edf7"
 
 SRC_URI = "git://github.com/projectacrn/acrn-hypervisor.git;branch=${SRCBRANCH}; \
 "
 
 # Snapshot tags are of the format:
 # acrn-<year>w<week>.<day>-<timestamp><pass|fail>
-PV = "2.3"
-SRCREV = "7e4b953185a7631f54fe1e130dd455a039c70ae9"
+PV = "2.4"
+SRCREV = "8aebf5526f8d542ca61c17a0db4f02298ffbc1ee"
 SRCBRANCH = "master"
 
 UPSTREAM_CHECK_GITTAGREGEX = "^v(?P<pver>\d+(\.\d+)+)$"


### PR DESCRIPTION
ACRN daily tag acrn-2021w03.1-180000p

Updated LICENSE md5sum. It has updates related to copyright years.

Signed-off-by: haribabug <haribabu.gandhamaneni@intel.com>
Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>