### PR TITLE
acrn-hypervisor: update to acrn-2021w04.3-180000p

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,11 @@ env:
 install:
  - git clone --depth=10 --branch=master git://git.yoctoproject.org/meta-intel ../meta-intel
  - git clone --depth=50 --branch=master git://git.yoctoproject.org/poky ../poky
+ - git clone --depth=50 --branch=master git://git.openembedded.org/meta-openembedded ../meta-openembedded
  - . ../poky/oe-init-build-env $TRAVIS_BUILD_DIR/build
  - bitbake-layers add-layer ../../meta-intel
+ - bitbake-layers add-layer ../../meta-openembedded/meta-oe
+ - bitbake-layers add-layer ../../meta-openembedded/meta-python
  - bitbake-layers add-layer ../../meta-acrn
 
 script:

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,7 +10,7 @@ BBFILE_PRIORITY_meta-acrn = "5"
 # Additional license directories.
 LICENSE_PATH += "${LAYERDIR}/custom-licenses"
 
-LAYERDEPENDS_meta-acrn = "core intel"
+LAYERDEPENDS_meta-acrn = "core intel meta-python"
 LAYERSERIES_COMPAT_meta-acrn = "dunfell gatesgarth"
 
 BBFILES_DYNAMIC += " \

--- a/recipes-core/acrn/acrn-common.inc
+++ b/recipes-core/acrn/acrn-common.inc
@@ -9,7 +9,7 @@ SRC_URI = "git://github.com/projectacrn/acrn-hypervisor.git;branch=${SRCBRANCH};
 # Snapshot tags are of the format:
 # acrn-<year>w<week>.<day>-<timestamp><pass|fail>
 PV = "2.4"
-SRCREV = "5c5d27235824e1c31c021b53454dc2ee2fc18aad"
+SRCREV = "2f7e0cde46388655d71f8f127a2e86dc818d7903"
 SRCBRANCH = "master"
 
 UPSTREAM_CHECK_GITTAGREGEX = "^v(?P<pver>\d+(\.\d+)+)$"

--- a/recipes-core/acrn/acrn-hypervisor.bb
+++ b/recipes-core/acrn/acrn-hypervisor.bb
@@ -13,7 +13,7 @@ inherit python3native deploy
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
-DEPENDS += "python3-kconfiglib-native acrn-hypervisor-native acpica-native"
+DEPENDS += "python3-kconfiglib-native acrn-hypervisor-native acpica-native python3-lxml-native"
 
 # parallel build could face build failure in case of config-tool method:
 #    | .config does not exist and no defconfig available for BOARD...

--- a/recipes-core/acrn/acrn-hypervisor/hypervisor-dont-build-pre_build.patch
+++ b/recipes-core/acrn/acrn-hypervisor/hypervisor-dont-build-pre_build.patch
@@ -1,9 +1,8 @@
-From 29939f8e4c06bf8a1c5d32b95fce367e245d3508 Mon Sep 17 00:00:00 2001
+From dd5ac409b33ba679cc2844429196182864569696 Mon Sep 17 00:00:00 2001
 From: Naveen Saini <naveen.kumar.saini@intel.com>
-Date: Tue, 8 Sep 2020 13:24:03 +0800
-Subject: [PATCH] hypervisor: dont build pre_build for target
-
-Execute pre_build_check during hypervisor build is causing error :
+Date: Tue, 19 Jan 2021 16:18:37 +0800
+Subject: [PATCH] Execute pre_build_check during hypervisor build is causing
+ error :
 
 | make: /data/yocto/poky/build-acrn/master-acrn-sos/work/intel_corei7_64-oe-linux/acrn-hypervisor/2.1-r0/build//hypervisor/hv_prebuild_check.out: Command not found
 
@@ -17,18 +16,18 @@ Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>
  1 file changed, 3 deletions(-)
 
 diff --git a/hypervisor/Makefile b/hypervisor/Makefile
-index e28dc63d..19c3d36e 100644
+index 437086a4..40f0aabf 100644
 --- a/hypervisor/Makefile
 +++ b/hypervisor/Makefile
-@@ -395,9 +395,6 @@ install-debug: $(HV_OBJDIR)/$(HV_FILE).map $(HV_OBJDIR)/$(HV_FILE).out
+@@ -378,9 +378,6 @@ install-debug: $(HV_OBJDIR)/$(HV_FILE).map $(HV_OBJDIR)/$(HV_FILE).out
  
  .PHONY: pre_build
- pre_build: $(HV_OBJDIR)/$(HV_CONFIG_H)
+ pre_build: $(HV_CONFIG_H) $(HV_CONFIG_TIMESTAMP)
 -	@echo "Start pre-build static check ..."
--	$(MAKE) -C $(PRE_BUILD_DIR) BOARD=$(BOARD) SCENARIO=$(SCENARIO) TARGET_DIR=$(TARGET_DIR)
+-	$(MAKE) -C $(PRE_BUILD_DIR) BOARD=$(BOARD) SCENARIO=$(SCENARIO) TARGET_DIR=$(HV_CONFIG_DIR)
 -	@$(HV_OBJDIR)/hv_prebuild_check.out
  	@echo "generate the binary of ACPI tables for pre-launched VMs ..."
- 	python3 ../misc/acrn-config/acpi_gen/bin_gen.py --board $(BOARD) --scenario $(SCENARIO) --asl $(TARGET_DIR) --out $(HV_OBJDIR)/acpi
+ 	python3 ../misc/acrn-config/acpi_gen/bin_gen.py --board $(BOARD) --scenario $(SCENARIO) --asl $(HV_CONFIG_DIR) --out $(HV_OBJDIR)/acpi
  
 -- 
 2.17.1

--- a/recipes-devtools/python/python-kconfiglib.inc
+++ b/recipes-devtools/python/python-kconfiglib.inc
@@ -1,8 +1,0 @@
-DESCRIPTION = "Kconfiglib is a Kconfig implementation in Python"
-LICENSE = "ISC"
-LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=712177a72a3937909543eda3ad1bfb7c"
-
-SRC_URI[md5sum] = "4ad68618824d4bad1d1de1d7eb838bba"
-SRC_URI[sha256sum] = "bed2cc2216f538eca4255a83a4588d8823563cdd50114f86cf1a2674e602c93c"
-
-BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/python/python3-kconfiglib_14.1.0.bb
+++ b/recipes-devtools/python/python3-kconfiglib_14.1.0.bb
@@ -1,2 +1,0 @@
-require python-kconfiglib.inc
-inherit pypi setuptools3


### PR DESCRIPTION
.travis.yml: fix meta-python dependency

python3-kconfiglib: drop recipe
This layer (meta-acrn) now depends on meta-python layer. meta-python
provides python3-kconfiglib, so no need to carry.


acrn-hypervisor: update to acrn-2021w04.3-180000p
Commits included:
2f7e0cde4 doc: update doc build instructions
329296f09 Makefile: remove rules related to Kconfig and TARGET_DIR
775214b71 Makefile: create and apply patches to generated sources
866c0881a Makefile: generate C configuration files at build time
2f6abbe75 acrn-config: add XSLT scripts to transform XMLs to config.[h|mk]
7a145253f acrn-config: add static allocators to rewrite scenario XMLs
9cff2bbdc acrn-config: add a script to generate config sources from XMLs
6c6fa5f34 Fix: HV: keep reshuffling on VBARs
5c5d27235 hv: remove bitmap_clear_lock of split-lock after completing emulation
ef411d4ac hv: ptirq: Shouldn't change sid if intx irq mapping was added

Introduced new dependency on python3-lxml module.
[https://github.com/projectacrn/acrn-hypervisor/commit/7a145253f343ea654e90973822ccde54574416ad]

Refreshed existing patch.

'make diffconfig' is not supported in Yocto build enviroment.
[https://github.com/projectacrn/acrn-hypervisor/commit/775214b7107dfa2fa4eb34f7f46e52bbaa2a5098]
layer.conf: add layer dependency on meta-python

Below dependencies are on meta-python:
python3-kconfiglib
python3-lxml
