### PR TITLE
linux-intel-acrn/5.4: update to 5.4.90

### DIFF
--- a/recipes-kernel/linux/linux-intel-acrn_5.4.inc
+++ b/recipes-kernel/linux/linux-intel-acrn_5.4.inc
@@ -9,9 +9,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 KBRANCH = "5.4/yocto"
 KMETA_BRANCH = "yocto-5.4"
 
-LINUX_VERSION ?= "5.4.81"
-SRCREV_machine ?= "b3d20595bdf59d0784cb8256445fff65df26c4ac"
-SRCREV_meta ?= "8930d401f840f6cdff4ac887f6f6832d8cd44112"
+LINUX_VERSION ?= "5.4.90"
+SRCREV_machine ?= "69bdbbbbb350cb1d296f98ba76a03a339d69970d"
+SRCREV_meta ?= "d676bf5ff7b7071e14f44498d2482c0a596f14cd"
 
 DEPENDS += "elfutils-native openssl-native util-linux-native"
 

--- a/recipes-kernel/linux/linux-intel-rt-acrn-uos_5.4.bb
+++ b/recipes-kernel/linux/linux-intel-rt-acrn-uos_5.4.bb
@@ -20,9 +20,9 @@ KMETA_BRANCH = "yocto-5.4"
 
 DEPENDS += "elfutils-native openssl-native util-linux-native"
 
-LINUX_VERSION ?= "5.4.78"
-SRCREV_machine ?= "d5fde3d31ce39557fac848a476e3473b14f2c042"
-SRCREV_meta ?= "8930d401f840f6cdff4ac887f6f6832d8cd44112"
+LINUX_VERSION ?= "5.4.87"
+SRCREV_machine ?= "db8c85db08a41d88738f4ddd2779567457d17e1d"
+SRCREV_meta ?= "d676bf5ff7b7071e14f44498d2482c0a596f14cd"
 
 LINUX_VERSION_EXTENSION = "-linux-intel-preempt-rt-acrn-uos"
 


### PR DESCRIPTION
linux-intel-acrn/5.4: update to 5.4.90
linux-intel-rt-acrn-uos/5.4: update to 5.4.87

Update kernel config to fix CONFIG_FW_LOADER mismatch warning
Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>