### PR TITLE
acrn: adjust python dependency due to recent configuration tool refinements

### DIFF
--- a/recipes-core/acrn/acrn-devicemodel.bb
+++ b/recipes-core/acrn/acrn-devicemodel.bb
@@ -4,7 +4,7 @@ SRC_URI += "file://dont-build-tools.patch"
 
 inherit python3native
 
-DEPENDS += "python3-kconfiglib-native util-linux libusb1 openssl libpciaccess acrn-tools"
+DEPENDS += "util-linux libusb1 openssl libpciaccess acrn-tools"
 
 # Tell the build where to find acrn-tools
 EXTRA_OEMAKE += "TOOLS_OUT=${STAGING_DIR_TARGET}${includedir}/acrn"

--- a/recipes-core/acrn/acrn-hypervisor.bb
+++ b/recipes-core/acrn/acrn-hypervisor.bb
@@ -13,7 +13,7 @@ inherit python3native deploy
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
-DEPENDS += "python3-kconfiglib-native acrn-hypervisor-native acpica-native python3-lxml-native"
+DEPENDS += "acrn-hypervisor-native acpica-native python3-lxml-native"
 
 # parallel build could face build failure in case of config-tool method:
 #    | .config does not exist and no defconfig available for BOARD...

--- a/recipes-core/acrn/acrn-hypervisor.bb
+++ b/recipes-core/acrn/acrn-hypervisor.bb
@@ -13,7 +13,7 @@ inherit python3native deploy
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
-DEPENDS += "acrn-hypervisor-native acpica-native python3-lxml-native"
+DEPENDS += "python3-xmlschema-native acrn-hypervisor-native acpica-native python3-lxml-native"
 
 # parallel build could face build failure in case of config-tool method:
 #    | .config does not exist and no defconfig available for BOARD...

--- a/recipes-devtools/python/python-elementpath.inc
+++ b/recipes-devtools/python/python-elementpath.inc
@@ -1,0 +1,5 @@
+DESCRIPTION = "Provide XPath 1.0 and 2.0 selectors for Python's ElementTree XML data structures, both for the standard ElementTree library and for the lxml.etree library."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=5dbb7fb7d72da3921202dd7b995d3ecf"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/python/python-xmlschema.inc
+++ b/recipes-devtools/python/python-xmlschema.inc
@@ -1,0 +1,9 @@
+DESCRIPTION = "The xmlschema library is an implementation of XML Schema for Python (supports Python 3.6+)."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=47489cb18c469474afeb259ed1d4832f"
+
+inherit pypi
+
+DEPENDS += "${PYTHON_PN}-elementpath"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/python/python3-elementpath_2.1.2.bb
+++ b/recipes-devtools/python/python3-elementpath_2.1.2.bb
@@ -1,0 +1,5 @@
+require python-elementpath.inc
+inherit pypi setuptools3
+
+SRC_URI[md5sum] = "887f60e9c4fb9b0804a38372b2798101"
+SRC_URI[sha256sum] = "23e1fed8d196d9a6cc4d220ef11fbe7eb8cff3a27848621c447e9d96134b2085"

--- a/recipes-devtools/python/python3-xmlschema_1.4.1.bb
+++ b/recipes-devtools/python/python3-xmlschema_1.4.1.bb
@@ -1,0 +1,5 @@
+require python-xmlschema.inc
+inherit pypi setuptools3
+
+SRC_URI[md5sum] = "f4c46f8c4415a0ca31dc2f623b668664"
+SRC_URI[sha256sum] = "ade693114ff2e4a9ed5a2371ce29ae888f689bc58e326e5796f8a7dc8954dd4a"


### PR DESCRIPTION
In ACRN v2.4 we plan to unify the configuration tools by using the XML-based approach everywhere. Kconfig is thus no longer used. With projectacrn/acrn-hypervisor#5645 it is now safe to remove kconfiglib from the dependency of ACRN.

Meanwhile a future PR for ACRN v2.4 will introduce XML Schema Definitions (XSDs) with assertions to define the schema of ACRN configuration data as well as to check their consistency. This requires an XSD implementation that is able to validate an XML file against XSD 1.1 (in which assertions are introduced). Unfortunately libxml2 (which is included in openembedded-core) can only handle XSD 1.0. As a result this PR also adds the Python3 xmlschema library for XML validation.