### PR TITLE
  linux-intel-acrn/5.4: update to 5.4.90

### DIFF
--- a/recipes-kernel/linux/linux-intel-acrn_5.4.inc
+++ b/recipes-kernel/linux/linux-intel-acrn_5.4.inc
@@ -9,9 +9,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 KBRANCH = "5.4/yocto"
 KMETA_BRANCH = "yocto-5.4"
 
-LINUX_VERSION ?= "5.4.81"
-SRCREV_machine ?= "b3d20595bdf59d0784cb8256445fff65df26c4ac"
-SRCREV_meta ?= "8930d401f840f6cdff4ac887f6f6832d8cd44112"
+LINUX_VERSION ?= "5.4.90"
+SRCREV_machine ?= "69bdbbbbb350cb1d296f98ba76a03a339d69970d"
+SRCREV_meta ?= "d676bf5ff7b7071e14f44498d2482c0a596f14cd"
 
 DEPENDS += "elfutils-native openssl-native util-linux-native"
 

--- a/recipes-kernel/linux/linux-intel-rt-acrn-uos_5.4.bb
+++ b/recipes-kernel/linux/linux-intel-rt-acrn-uos_5.4.bb
@@ -20,9 +20,9 @@ KMETA_BRANCH = "yocto-5.4"
 
 DEPENDS += "elfutils-native openssl-native util-linux-native"
 
-LINUX_VERSION ?= "5.4.78"
-SRCREV_machine ?= "d5fde3d31ce39557fac848a476e3473b14f2c042"
-SRCREV_meta ?= "8930d401f840f6cdff4ac887f6f6832d8cd44112"
+LINUX_VERSION ?= "5.4.87"
+SRCREV_machine ?= "db8c85db08a41d88738f4ddd2779567457d17e1d"
+SRCREV_meta ?= "d676bf5ff7b7071e14f44498d2482c0a596f14cd"
 
 LINUX_VERSION_EXTENSION = "-linux-intel-preempt-rt-acrn-uos"
 


### PR DESCRIPTION
  linux-intel-rt-acrn-uos/5.4: update to 5.4.87
  patchset rt48.

and 

  tag 'v5.4.90': (169 commits)
  Linux 5.4.90
  regmap: debugfs: Fix a reversed if statement in regmap_debugfs_init()
  net: drop bogus skb with CHECKSUM_PARTIAL and offset beyond end of trimmed packet
  block: fix use-after-free in disk_part_iter_next
  KVM: arm64: Don't access PMCR_EL0 when no PMU is available
  net: mvpp2: disable force link UP during port init procedure
  regulator: qcom-rpmh-regulator: correct hfsmps515 definition
  wan: ds26522: select CONFIG_BITREVERSE
  regmap: debugfs: Fix a memory leak when calling regmap_attach_dev
  net/mlx5e: Fix two double free cases
  net/mlx5e: Fix memleak in mlx5e_create_l2_table_groups
  bpftool: Fix compilation failure for net.o with older glibc
  iommu/intel: Fix memleak in intel_irq_remapping_alloc
  lightnvm: select CONFIG_CRC32
  block: rsxx: select CONFIG_CRC32
  wil6210: select CONFIG_CRC32
  qed: select CONFIG_CRC32
  dmaengine: xilinx_dma: fix mixed_enum_type coverity warning
  dmaengine: xilinx_dma: fix incompatible param warning in _child_probe()
  dmaengine: xilinx_dma: check dma_async_device_register return value
  ...

  Update kernel config to fix CONFIG_FW_LOADER mismatch warning

  Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>
