### PR TITLE
linux-intel-ese-lts-acrn-sos: sos cfg always override inherited cfg

### DIFF
--- a/dynamic-layers/intel-ese-bsp/recipes-kernel/linux/linux-intel-ese-lts-acrn-sos_5.4.bb
+++ b/dynamic-layers/intel-ese-bsp/recipes-kernel/linux/linux-intel-ese-lts-acrn-sos_5.4.bb
@@ -8,7 +8,8 @@ SUMMARY = "Linux Intel ESE Kernel with ACRN enabled (SOS)"
 
 KERNEL_FEATURES_append = " features/criu/criu-enable.scc \
                            features/docker/docker.scc \
-                          cgl/cfg/iscsi.scc \
+                           cgl/cfg/iscsi.scc \
+                           sos_5.4.scc \
 "
 
 SRC_URI_append = " ${@get_scenario_cfg(d)}"


### PR DESCRIPTION
Ensure SOS specific configuration override cfg inherit from ese kernel.

Also fix indentation.

Signed-off-by: Chee Yang Lee <chee.yang.lee@intel.com>