### PR TITLE
acrn-hypervisor: drop BOARD_FILE/SCENARIO_FILE config variables

### DIFF
--- a/recipes-core/acrn/acrn-devicemodel.bb
+++ b/recipes-core/acrn/acrn-devicemodel.bb
@@ -4,7 +4,7 @@ SRC_URI += "file://dont-build-tools.patch"
 
 inherit python3native
 
-DEPENDS += "python3-kconfiglib-native util-linux libusb1 openssl libpciaccess acrn-tools"
+DEPENDS += "util-linux libusb1 openssl libpciaccess acrn-tools"
 
 # Tell the build where to find acrn-tools
 EXTRA_OEMAKE += "TOOLS_OUT=${STAGING_DIR_TARGET}${includedir}/acrn"

--- a/recipes-core/acrn/acrn-hypervisor.bb
+++ b/recipes-core/acrn/acrn-hypervisor.bb
@@ -5,7 +5,6 @@ ACRN_SCENARIO  ?= "industry"
 
 EXTRA_OEMAKE += "HV_OBJDIR=${B}/hypervisor "
 EXTRA_OEMAKE += "BOARD=${ACRN_BOARD} SCENARIO=${ACRN_SCENARIO}"
-EXTRA_OEMAKE += "BOARD_FILE=${S}/misc/acrn-config/xmls/board-xmls/${ACRN_BOARD}.xml SCENARIO_FILE=${S}/misc/acrn-config/xmls/config-xmls/${ACRN_BOARD}/${ACRN_SCENARIO}.xml"
 
 SRC_URI_append_class-target += "file://hypervisor-dont-build-pre_build.patch"
 
@@ -13,7 +12,7 @@ inherit python3native deploy
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
-DEPENDS += "python3-kconfiglib-native acrn-hypervisor-native acpica-native python3-lxml-native"
+DEPENDS += "acrn-hypervisor-native acpica-native python3-lxml-native"
 
 # parallel build could face build failure in case of config-tool method:
 #    | .config does not exist and no defconfig available for BOARD...


### PR DESCRIPTION
Due to recent changes, BOARD/SCENARIO take precedence over the
BOARD_FILE/SCENARIO_FILE. So BOARD_FILE/SCENARIO_FILE becomes obsolete.

Recent change, use BOARD/SCENARIO configuration variables to fetch
releated xml files automaticially.

Drop python3-konfiglib-native from DEPENDS, as kconfig is not used anymore.

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>