### PR TITLE
acrn: update to tag acrn-2021w05.5-180000p

### DIFF
--- a/recipes-core/acrn/acrn-common.inc
+++ b/recipes-core/acrn/acrn-common.inc
@@ -9,7 +9,7 @@ SRC_URI = "git://github.com/projectacrn/acrn-hypervisor.git;branch=${SRCBRANCH};
 # Snapshot tags are of the format:
 # acrn-<year>w<week>.<day>-<timestamp><pass|fail>
 PV = "2.4"
-SRCREV = "2f7e0cde46388655d71f8f127a2e86dc818d7903"
+SRCREV = "f7772a98ee8a9ee6fbbb2227df69fae95f99e49e"
 SRCBRANCH = "master"
 
 UPSTREAM_CHECK_GITTAGREGEX = "^v(?P<pver>\d+(\.\d+)+)$"

--- a/recipes-core/acrn/acrn-hypervisor/hypervisor-dont-build-pre_build.patch
+++ b/recipes-core/acrn/acrn-hypervisor/hypervisor-dont-build-pre_build.patch
@@ -1,7 +1,7 @@
-From dd5ac409b33ba679cc2844429196182864569696 Mon Sep 17 00:00:00 2001
+From c82b2e2b36772989cb14c9ee5d46bda63850d10f Mon Sep 17 00:00:00 2001
 From: Naveen Saini <naveen.kumar.saini@intel.com>
-Date: Tue, 19 Jan 2021 16:18:37 +0800
-Subject: [PATCH] Execute pre_build_check during hypervisor build is causing
+Date: Mon, 25 Jan 2021 18:02:12 +0800
+Subject: [PATCH] Execute pre_build_check during hypervisor build is causing 
  error :
 
 | make: /data/yocto/poky/build-acrn/master-acrn-sos/work/intel_corei7_64-oe-linux/acrn-hypervisor/2.1-r0/build//hypervisor/hv_prebuild_check.out: Command not found
@@ -16,7 +16,7 @@ Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>
  1 file changed, 3 deletions(-)
 
 diff --git a/hypervisor/Makefile b/hypervisor/Makefile
-index 437086a4..40f0aabf 100644
+index 0f2c0414..249fb4b5 100644
 --- a/hypervisor/Makefile
 +++ b/hypervisor/Makefile
 @@ -378,9 +378,6 @@ install-debug: $(HV_OBJDIR)/$(HV_FILE).map $(HV_OBJDIR)/$(HV_FILE).out
@@ -27,7 +27,7 @@ index 437086a4..40f0aabf 100644
 -	$(MAKE) -C $(PRE_BUILD_DIR) BOARD=$(BOARD) SCENARIO=$(SCENARIO) TARGET_DIR=$(HV_CONFIG_DIR)
 -	@$(HV_OBJDIR)/hv_prebuild_check.out
  	@echo "generate the binary of ACPI tables for pre-launched VMs ..."
- 	python3 ../misc/acrn-config/acpi_gen/bin_gen.py --board $(BOARD) --scenario $(SCENARIO) --asl $(HV_CONFIG_DIR) --out $(HV_OBJDIR)/acpi
+ 	python3 ../misc/config_tools/acpi_gen/bin_gen.py --board $(BOARD) --scenario $(SCENARIO) --asl $(HV_CONFIG_DIR) --out $(HV_OBJDIR)/acpi
  
 -- 
 2.17.1

--- a/recipes-core/acrn/acrn-life-mngr.bb
+++ b/recipes-core/acrn/acrn-life-mngr.bb
@@ -7,7 +7,7 @@ REQUIRED_DISTRO_FEATURES = "systemd"
 EXTRA_OEMAKE += " OUT_DIR=${B} "
 
 do_compile() {
-	oe_runmake -C misc/life_mngr
+	oe_runmake -C misc/services/life_mngr
 }
 
 do_install() {


### PR DESCRIPTION
Refreshed patch and updated life_mngr directory path.

Ref: https://github.com/projectacrn/acrn-hypervisor/commit/97c9b240303602141fa116d5f315c62b6958b5fa

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>