### PR TITLE
acrn: update to tag acrn-2021w06.3-180000p

### DIFF
--- a/recipes-core/acrn/acrn-common.inc
+++ b/recipes-core/acrn/acrn-common.inc
@@ -9,7 +9,7 @@ SRC_URI = "git://github.com/projectacrn/acrn-hypervisor.git;branch=${SRCBRANCH};
 # Snapshot tags are of the format:
 # acrn-<year>w<week>.<day>-<timestamp><pass|fail>
 PV = "2.4"
-SRCREV = "f7772a98ee8a9ee6fbbb2227df69fae95f99e49e"
+SRCREV = "0ea991fbed978294e0c5c5ef2c0488e55ede8352"
 SRCBRANCH = "master"
 
 UPSTREAM_CHECK_GITTAGREGEX = "^v(?P<pver>\d+(\.\d+)+)$"


### PR DESCRIPTION
It include fix for gcc10 compilation failure.

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>