### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+build*/
+pyshtables.py
+*.swp
+*.orig
+*.rej
+/*.patch
+*~
+scripts/lib/wic/plugins/source/__pycache__


### PR DESCRIPTION
Add reasonable .gitignore (borrowed from meta-virtualization).

In particular, automated updates, e.g. 'kas build --update'
always mark meta-acrn as "dirty" because of
scripts/lib/wic/plugins/source/__pycache__

Signed-off-by: Tim Orling <timothy.t.orling@linux.intel.com>