### PR TITLE
[Gatesgarth] Kernel updates 

### DIFF
--- a/recipes-kernel/linux/linux-intel-acrn_4.19.inc
+++ b/recipes-kernel/linux/linux-intel-acrn_4.19.inc
@@ -8,9 +8,9 @@ SRC_URI_append = "  file://0001-menuconfig-mconf-cfg-Allow-specification-of-ncur
 KBRANCH = "4.19/base"
 KMETA_BRANCH = "yocto-4.19"
 
-LINUX_VERSION ?= "4.19.163"
-SRCREV_machine ?= "e96097be885e02da48a972a0b0d2dd27d8e00e57"
-SRCREV_meta ?= "6dd03685eaf5d27cd6e88ee888c0d42e09befd17"
+LINUX_VERSION ?= "4.19.174"
+SRCREV_machine ?= "61682da75b19bdf464c7f8c5e78af0548a89d91c"
+SRCREV_meta ?= "147f6b827c6e7766cb2b61da4e17479ffcd216c2"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 

--- a/recipes-kernel/linux/linux-intel-acrn_5.4.inc
+++ b/recipes-kernel/linux/linux-intel-acrn_5.4.inc
@@ -9,9 +9,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 KBRANCH = "5.4/yocto"
 KMETA_BRANCH = "yocto-5.4"
 
-LINUX_VERSION ?= "5.4.81"
-SRCREV_machine ?= "b3d20595bdf59d0784cb8256445fff65df26c4ac"
-SRCREV_meta ?= "8930d401f840f6cdff4ac887f6f6832d8cd44112"
+LINUX_VERSION ?= "5.4.96"
+SRCREV_machine ?= "a649a51485b7fc810a15ae44a0b393d4e4b91392"
+SRCREV_meta ?= "4f6d6c23cc8ca5d9c39b1efc2619b1dfec1ef2bc"
 
 DEPENDS += "elfutils-native openssl-native util-linux-native"
 

--- a/recipes-kernel/linux/linux-intel-rt-acrn-uos_4.19.bb
+++ b/recipes-kernel/linux/linux-intel-rt-acrn-uos_4.19.bb
@@ -20,9 +20,9 @@ KMETA_BRANCH = "yocto-4.19"
 
 DEPENDS += "elfutils-native openssl-native util-linux-native"
 
-LINUX_VERSION ?= "4.19.160"
-SRCREV_machine ?= "ace42c087099e9807d62e3a6aedeee5b5abb643a"
-SRCREV_meta ?= "6dd03685eaf5d27cd6e88ee888c0d42e09befd17"
+LINUX_VERSION ?= "4.19.165"
+SRCREV_machine ?= "4b0ea4d493b0f8fca0979b4351660cc4e01594c1"
+SRCREV_meta ?= "147f6b827c6e7766cb2b61da4e17479ffcd216c2"
 
 LINUX_VERSION_EXTENSION = "-linux-intel-preempt-rt-acrn-uos"
 

--- a/recipes-kernel/linux/linux-intel-rt-acrn-uos_5.4.bb
+++ b/recipes-kernel/linux/linux-intel-rt-acrn-uos_5.4.bb
@@ -20,9 +20,9 @@ KMETA_BRANCH = "yocto-5.4"
 
 DEPENDS += "elfutils-native openssl-native util-linux-native"
 
-LINUX_VERSION ?= "5.4.78"
-SRCREV_machine ?= "d5fde3d31ce39557fac848a476e3473b14f2c042"
-SRCREV_meta ?= "8930d401f840f6cdff4ac887f6f6832d8cd44112"
+LINUX_VERSION ?= "5.4.93"
+SRCREV_machine ?= "6d57e4c1caf4b50e55d27251a39312fec10cd870"
+SRCREV_meta ?= "4f6d6c23cc8ca5d9c39b1efc2619b1dfec1ef2bc"
 
 LINUX_VERSION_EXTENSION = "-linux-intel-preempt-rt-acrn-uos"
 


### PR DESCRIPTION
linux-intel-rt-acrn-uos: update to v4.19.165-rt70 and v5.4.93-rt51 
linux-intel-acrn: update to v4.19.174 and  v5.4.96 
