### PR TITLE
linux-intel-ese-lts-acrn-sos: ensure sos_5.4_hybrid_rt_fusa override ese config

### DIFF
--- a/dynamic-layers/intel-ese-bsp/recipes-kernel/linux/linux-intel-ese-lts-acrn-sos_5.4.bb
+++ b/dynamic-layers/intel-ese-bsp/recipes-kernel/linux/linux-intel-ese-lts-acrn-sos_5.4.bb
@@ -1,6 +1,7 @@
 require linux-intel-ese-acrn.inc
 
-SRC_URI_append = "  file://sos_5.4.scc"
+SRC_URI_append = " ${@bb.utils.contains('ACRN_BOARD', 'ehl-crb-b', bb.utils.contains('ACRN_SCENARIO', 'hybrid_rt_fusa', 'file://sos_5.4_hybrid_rt_fusa.scc', '', d), '', d)} \
+                   file://sos_5.4.scc"
 
 LINUX_VERSION_EXTENSION = "-linux-intel-ese-lts-acrn-sos"
 
@@ -9,13 +10,7 @@ SUMMARY = "Linux Intel ESE Kernel with ACRN enabled (SOS)"
 KERNEL_FEATURES_append = " features/criu/criu-enable.scc \
                            features/docker/docker.scc \
                            cgl/cfg/iscsi.scc \
+                           ${@bb.utils.contains('ACRN_BOARD', 'ehl-crb-b', bb.utils.contains('ACRN_SCENARIO', 'hybrid_rt_fusa', 'sos_5.4_hybrid_rt_fusa.scc', '', d), '', d)} \
                            sos_5.4.scc \
 "
 
-SRC_URI_append = " ${@get_scenario_cfg(d)}"
-
-def get_scenario_cfg(d):
-    if bb.utils.contains('ACRN_BOARD', 'ehl-crb-b', True, False, d):
-        if bb.utils.contains('ACRN_SCENARIO', 'hybrid_rt_fusa', True, False, d):
-            return 'file://sos_5.4_hybrid_rt_fusa.scc'
-    return ''


### PR DESCRIPTION
ensure sos_5.4_hybrid_rt_fusa override ese config.

get_scenario_cfg does not work for both SRC_URI and KERNEL_FEATURES so
drop it and replace with nested bb.utils.contains.

Signed-off-by: Lee Chee Yang <chee.yang.lee@intel.com>