### PR TITLE
acrn: adapt to recent changes to misc/Makefile

### DIFF
--- a/recipes-core/acrn/acrn-common.inc
+++ b/recipes-core/acrn/acrn-common.inc
@@ -9,7 +9,7 @@ SRC_URI = "git://github.com/projectacrn/acrn-hypervisor.git;branch=${SRCBRANCH};
 # Snapshot tags are of the format:
 # acrn-<year>w<week>.<day>-<timestamp><pass|fail>
 PV = "2.4"
-SRCREV = "5070d556e41315f1877bccc49e0cb818637c9ad7"
+SRCREV = "23d8202c776db4ace0950ac4bf68d478ae8cb8f4"
 SRCBRANCH = "release_2.4"
 
 UPSTREAM_CHECK_GITTAGREGEX = "^v(?P<pver>\d+(\.\d+)+)$"

--- a/recipes-core/acrn/acrn-tools/no-life-mngr.patch
+++ b/recipes-core/acrn/acrn-tools/no-life-mngr.patch
@@ -11,37 +11,40 @@ Upstream-Status: Inappropriate
 
 Signed-off-by: Lee Chee Yang <chee.yang.lee@intel.com>
 ---
- misc/Makefile | 9 ++++-----
- 1 file changed, 4 insertions(+), 5 deletions(-)
+ misc/Makefile | 11 +++++------
+ 1 file changed, 5 insertions(+), 6 deletions(-)
 
 diff --git a/misc/Makefile b/misc/Makefile
 index 1a510ad3..a65023ed 100644
 --- a/misc/Makefile
 +++ b/misc/Makefile
-@@ -2,9 +2,9 @@ T := $(CURDIR)
- OUT_DIR ?= $(shell mkdir -p $(T)/build;cd $(T)/build;pwd)
- RELEASE ?= 0
-
--.PHONY: all acrn-crashlog acrnlog acrn-manager acrntrace acrnbridge life_mngr
-+.PHONY: all acrn-crashlog acrnlog acrn-manager acrntrace acrnbridge 
- ifeq ($(RELEASE),0)
--all: acrn-crashlog acrnlog acrn-manager acrntrace acrnbridge life_mngr
-+all: acrn-crashlog acrnlog acrn-manager acrntrace acrnbridge 
- else
- all: acrn-manager acrnbridge life_mngr
+@@ -14,11 +14,11 @@ else
+   endif
  endif
-@@ -38,10 +38,9 @@ clean:
-
+ 
+-.PHONY: all acrn-crashlog acrnlog acrn-manager acrntrace acrnbridge life_mngr
++.PHONY: all acrn-crashlog acrnlog acrn-manager acrntrace acrnbridge
+ ifeq ($(RELEASE),n)
+-all: acrn-crashlog acrnlog acrn-manager acrntrace acrnbridge life_mngr
++all: acrn-crashlog acrnlog acrn-manager acrntrace acrnbridge
+ else
+-all: acrn-manager acrnbridge life_mngr
++all: acrn-manager acrnbridge
+ endif
+ 
+ acrn-crashlog:
+@@ -50,10 +50,9 @@ clean:
+ 
  .PHONY: install
- ifeq ($(RELEASE),0)
+ ifeq ($(RELEASE),n)
 -install: acrn-crashlog-install acrnlog-install acrn-manager-install acrntrace-install acrnbridge-install \
 -	acrn-life-mngr-install
-+install: acrn-crashlog-install acrnlog-install acrn-manager-install acrntrace-install acrnbridge-install 
++install: acrn-crashlog-install acrnlog-install acrn-manager-install acrntrace-install acrnbridge-install
  else
 -install: acrn-manager-install acrnbridge-install acrn-life-mngr-install
-+install: acrn-manager-install acrnbridge-install 
++install: acrn-manager-install acrnbridge-install
  endif
-
+ 
  acrn-crashlog-install:
 -- 
 2.25.1


### PR DESCRIPTION
This patch updates recipes-core/acrn/acrn-tools/no-life-mngr.patch in
response to a recent update to ACRN
makefiles (projectacrn/acrn-hypervisor#5791).

Signed-off-by: Junjie Mao <junjie.mao@intel.com>