### PR TITLE
linux-intel-acrn-sos: fix scc filename typo

### DIFF
--- a/recipes-kernel/linux/linux-intel-acrn-sos_5.4.bb
+++ b/recipes-kernel/linux/linux-intel-acrn-sos_5.4.bb
@@ -1,6 +1,9 @@
 require linux-intel-acrn_5.4.inc
 
-SRC_URI_append = "  file://sos_5.4.scc"
+SRC_URI_append = " ${@bb.utils.contains('ACRN_BOARD', \
+                    'ehl-crb-b', bb.utils.contains('ACRN_SCENARIO', 'hybrid_rt_fusa', 'file://sos_5.4_hybrid_rt_fusa.scc', '', d), \
+                    '', d)} \
+                   file://sos_5.4.scc"
 
 LINUX_VERSION_EXTENSION = "-linux-intel-acrn-sos"
 
@@ -8,17 +11,11 @@ SUMMARY = "Linux Kernel with ACRN enabled (SOS)"
 
 KERNEL_FEATURES_append = " features/criu/criu-enable.scc \
                           cgl/cfg/iscsi.scc \
+                          ${@bb.utils.contains('ACRN_BOARD', 'ehl-crb-b', \
+                            bb.utils.contains('ACRN_SCENARIO', 'hybrid_rt_fusa', 'sos_5.4_hybrid_rt_fusa.scc', '', d), '', d)} \
                           sos_5.4.scc \
 "
 
 # sos_5.4.scc override CONFIG_REFCOUNT_FULL set in security.scc is causing warning during
 # config audit. Suppress this harmless warning.
 KCONF_AUDIT_LEVEL = "0"
-
-SRC_URI_append = " ${@get_scenario_cfg(d)}"
-
-def get_scenario_cfg(d):
-    if bb.utils.contains('ACRN_BOARD', 'ehl-crb-b', True, False, d):
-        if bb.utils.contains('ACRN_SCENARIO', 'hybrid_rt_fusa', True, False, d):
-            return 'file://sos_5.4_hybrid_rt.scc'
-    return ''


### PR DESCRIPTION
Clean up, use nested bb.utils.contains and add as KERNEL_FEATURES.

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>