### PR TITLE
acrn-tools: adjust life_mngr patch to reflect latest changes upstream

### DIFF
--- a/recipes-core/acrn/acrn-devicemodel.bb
+++ b/recipes-core/acrn/acrn-devicemodel.bb
@@ -1,13 +1,15 @@
 require acrn-common.inc
 
-SRC_URI += "file://dont-build-tools.patch"
+SRC_URI += "file://dont-build-tools.patch \
+            file://allow-to-pass-compiler-and-linker-flags.patch \
+            "
 
 inherit python3native
 
 DEPENDS += "util-linux libusb1 openssl libpciaccess acrn-tools"
 
 # Tell the build where to find acrn-tools
-EXTRA_OEMAKE += "TOOLS_OUT=${STAGING_DIR_TARGET}${includedir}/acrn"
+EXTRA_OEMAKE += "COPTS=${STAGING_DIR_TARGET}${includedir}/acrn"
 
 EXTRA_OEMAKE += "ASL_COMPILER=${bindir}/iasl"
 

--- a/recipes-core/acrn/acrn-devicemodel/allow-to-pass-compiler-and-linker-flags.patch
+++ b/recipes-core/acrn/acrn-devicemodel/allow-to-pass-compiler-and-linker-flags.patch
@@ -1,0 +1,35 @@
+From d44f7502ff0dca7ebe84cad06da469eb60865000 Mon Sep 17 00:00:00 2001
+From: Naveen Saini <naveen.kumar.saini@intel.com>
+Date: Tue, 9 Mar 2021 09:51:29 +0800
+Subject: [PATCH] Makefile: allow to pass compiler and linker flags
+
+Upstream-Status: Inappropriate [oe-specific]
+
+Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>
+---
+ devicemodel/Makefile | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/devicemodel/Makefile b/devicemodel/Makefile
+index cea0b15b..95dd1b94 100644
+--- a/devicemodel/Makefile
++++ b/devicemodel/Makefile
+@@ -41,6 +41,7 @@ CFLAGS += -I$(BASEDIR)/include
+ CFLAGS += -I$(BASEDIR)/include/public
+ CFLAGS += -I$(DM_OBJDIR)/include
+ CFLAGS += -I$(TOOLS_OUT)/services
++CFLAGS += -I$(COPTS)
+ 
+ ifneq (, $(DM_ASL_COMPILER))
+ CFLAGS += -DASL_COMPILER=\"$(DM_ASL_COMPILER)\"
+@@ -75,6 +76,7 @@ LDFLAGS += -Wl,-z,noexecstack
+ LDFLAGS += -Wl,-z,relro,-z,now
+ LDFLAGS += -pie
+ LDFLAGS += -L$(TOOLS_OUT)/services
++LDFLAGS += -L$(COPTS)
+ 
+ LIBS = -lrt
+ LIBS += -lpthread
+-- 
+2.17.1
+

--- a/recipes-core/acrn/acrn-tools.bb
+++ b/recipes-core/acrn/acrn-tools.bb
@@ -5,7 +5,7 @@ inherit pkgconfig systemd
 DEPENDS += "numactl systemd e2fsprogs libevent libxml2 openssl"
 RDEPENDS_${PN} += "bash"
 
-SRC_URI += " file://no-life-mngr.patch \
+SRC_URI += " file://0001-tools-do-not-build-life_mngr-by-default.patch \
 "
 
 do_compile() {

--- a/recipes-core/acrn/acrn-tools/0001-tools-do-not-build-life_mngr-by-default.patch
+++ b/recipes-core/acrn/acrn-tools/0001-tools-do-not-build-life_mngr-by-default.patch
@@ -1,0 +1,52 @@
+From d6efac85c700ea4595b8b56df8458c461ff77b26 Mon Sep 17 00:00:00 2001
+From: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>
+Date: Wed, 3 Mar 2021 10:24:38 +0100
+Subject: [PATCH] tools: do not build life_mngr by default
+
+Do not build (or install) the ACRN life_mngr by default as this is
+a User VM tool, not one to be used and run in the Service VM.
+
+The component can still be built independantly by invoking
+'make -C misc life_mngr' (components will be built and placed in
+'misc/build/services/' by default).
+
+Upstream-Status: Pending
+
+Tracked-On: #5660
+Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>
+---
+ misc/Makefile | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/misc/Makefile b/misc/Makefile
+index 317490b9e..8a2bc5024 100644
+--- a/misc/Makefile
++++ b/misc/Makefile
+@@ -21,9 +21,9 @@ endif
+ 
+ .PHONY: all acrn-manager acrnbridge life_mngr acrn-crashlog acrnlog acrntrace
+ ifeq ($(RELEASE),n)
+-all: acrn-manager acrnbridge life_mngr acrn-crashlog acrnlog acrntrace
++all: acrn-manager acrnbridge acrn-crashlog acrnlog acrntrace
+ else
+-all: acrn-manager acrnbridge life_mngr
++all: acrn-manager acrnbridge
+ endif
+ 
+ acrn-manager:
+@@ -55,10 +55,10 @@ clean:
+ 
+ .PHONY: install
+ ifeq ($(RELEASE),n)
+-install: acrn-manager-install acrnbridge-install acrn-life-mngr-install acrn-crashlog-install \
++install: acrn-manager-install acrnbridge-install acrn-crashlog-install \
+ 	acrnlog-install acrntrace-install
+ else
+-install: acrn-manager-install acrnbridge-install acrn-life-mngr-install
++install: acrn-manager-install acrnbridge-install
+ endif
+ 
+ acrn-manager-install:
+-- 
+2.25.1
+


### PR DESCRIPTION
Update patch used to not build 'life_mngr' by default to reflect the
latest Makefile changes upstream.

Created a local Makefile patch, to inject compiler and linker flags
to source Makefile.

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>
Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>