### PR TITLE
Master next installer

### DIFF
--- a/conf/distro/acrn-demo-sos.conf
+++ b/conf/distro/acrn-demo-sos.conf
@@ -2,6 +2,7 @@ require conf/distro/include/acrn-demo.inc
 
 DISTRO .= "-sos"
 DISTRO_NAME += "(SOS)"
+DISTRO_FEATURES += "SOS"
 
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-intel-acrn-sos"
 PREFERRED_VERSION_linux-intel-acrn-sos ?= "5.4%"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -118,7 +118,7 @@ This forwards ports 1-1 and 1-2 into the UOS, which on Skull Canyon is the two f
 
 ### Install onto NUC
 
-To install the image on to NUC, you could burn the .wic.acrn image to the target NUC internal storage.
+To install the image on to NUC, you could burn the .wic image to the target NUC internal storage.
 
 Alternatively, you could build a wic based installer image where you can burn the .wic image onto USB flash drive and use USB flash drive as installer. To build the installer image for ACRN, add below lines to `local.conf`:
 
@@ -130,10 +130,7 @@ Then this in `conf/multiconfig/installer.conf`:
 
 ```
 # use the installer wks file
-WKS_FILE = "image-installer.wks.in"
-
-# do not need to convert wic to wic.acrn
-IMAGE_FSTYPES_remove="wic.acrn"
+WKS_FILE_pn-acrn-image-base = "image-installer.wks.in"
 
 # build initramsfs to start the installation
 INITRD_IMAGE_LIVE="core-image-minimal-initramfs"
@@ -145,11 +142,10 @@ IMAGE_TYPEDEP_wic = "ext4"
 # content to be install
 IMAGE_BOOT_FILES_append = "\
     ${KERNEL_IMAGETYPE} \
-    microcode.cpio \
-    acrn.efi;EFI/BOOT/acrn.efi \
-    systemd-bootx64.efi;EFI/BOOT/bootx64.efi \
-    ${IMAGE_ROOTFS}/boot/loader/loader.conf;loader/loader.conf \
-    ${IMAGE_ROOTFS}/boot/loader/entries/boot.conf;loader/entries/boot.conf \
+    acrn.bin;esp/acrn.bin \
+    microcode.cpio;esp/microcode.cpio \
+    grub-efi-bootx64.efi;EFI/BOOT/bootx64.efi \
+    ${IMAGE_ROOTFS}/boot/EFI/BOOT/grub.cfg;esp/EFI/BOOT/grub.cfg \
     ${IMGDEPLOYDIR}/${IMAGE_BASENAME}-${MACHINE}.ext4;rootfs.img \
 "
 ```

--- a/recipes-bsp/grub/acrn-grub-bootconf.inc
+++ b/recipes-bsp/grub/acrn-grub-bootconf.inc
@@ -1,0 +1,50 @@
+inherit image-acrn
+
+do_configure_append(){
+    bb.build.exec_func('update_acrn_efi_cfg', d)
+}
+
+python update_acrn_efi_cfg() {
+    cfile = d.getVar('GRUB_CFG')
+    if not cfile:
+        bb.fatal('Unable to read GRUB_CFG')
+
+    root = d.getVar('GRUB_ROOT')
+    if not root:
+        bb.fatal('GRUB_ROOT not defined')
+
+    # read configuration generate by oe
+    try:
+         cfg = open(cfile, 'rt').read().splitlines()
+    except OSError:
+        bb.fatal('Unable to open %s' % cfile)
+
+    # change default boot option
+    for l in range(len(cfg)):
+        if cfg[l].startswith("default="):
+            cfg[l] = "default='ACRN (Yocto)'"
+            break
+
+    localdata = d.createCopy()
+    cfg.append("\nmenuentry 'ACRN (Yocto)'{\n")
+
+    cfg.append("multiboot2 /acrn.bin %s %s \n" % ( \
+        replace_rootfs_uuid(d, root), \
+        replace_rootfs_uuid(d, localdata.getVar('APPEND')) ) )
+
+    boot_confs = localdata.getVar("ACRN_EFI_BOOT_CONF").split(";")
+    for boot_conf in boot_confs:
+        if not boot_conf:
+             continue
+        conf = boot_conf.split(":")
+        if len(conf) == 2:
+            cfg.append("module2 /%s %s\n" %(conf[0] ,conf[1]))
+        elif len(conf) == 3:
+            cfg.append("module2 /%s %s %s\n" %(conf[0] ,conf[1] ,conf[2]))
+        else:
+            bb.error("unable to parse ACRN_EFI_BOOT_CONF, in \"%s\" exiting" % boot_conf )
+
+    cfg.append('\n}\n')
+
+    open(cfile,'w+').write('\n'.join(cfg))
+}

--- a/recipes-bsp/grub/grub-bootconf_1.00.bbappend
+++ b/recipes-bsp/grub/grub-bootconf_1.00.bbappend
@@ -1,0 +1,1 @@
+require ${@bb.utils.contains("DISTRO_FEATURES", "SOS", "acrn-grub-bootconf.inc", "", d)}


### PR DESCRIPTION
docs: update installer steps
grub-bootconf: add bbappend

Add bbappend to build grub boot menu with support for multiboot and acrn
specific setting.

Signed-off-by: Lee Chee Yang <chee.yang.lee@intel.com>
Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>
