### PR TITLE
acrn: update to tag acrn-2021w13.3-180000p

### DIFF
--- a/recipes-core/acrn/acrn-common.inc
+++ b/recipes-core/acrn/acrn-common.inc
@@ -9,7 +9,7 @@ SRC_URI = "git://github.com/projectacrn/acrn-hypervisor.git;branch=${SRCBRANCH};
 # Snapshot tags are of the format:
 # acrn-<year>w<week>.<day>-<timestamp><pass|fail>
 PV = "2.4"
-SRCREV = "95f38ac12ea11869849c9c12894ca003d0ffd985"
+SRCREV = "b33c4181329d68f46338afc3f623df27bee2033f"
 SRCBRANCH = "release_2.4"
 
 UPSTREAM_CHECK_GITTAGREGEX = "^v(?P<pver>\d+(\.\d+)+)$"


### PR DESCRIPTION
updated with the ACRN daily tag acrn-2021w13.3-180000p on ACRN release_2.4 branch.