### PR TITLE
acrn-kernel: update acrn-kernel SRCREV to version 5.4.90

### DIFF
--- a/recipes-kernel/linux/acrn-kernel_5.4.inc
+++ b/recipes-kernel/linux/acrn-kernel_5.4.inc
@@ -5,5 +5,5 @@ KBRANCH = "master"
 SRC_URI_remove = "git://github.com/intel/linux-intel-lts.git;protocol=https;name=machine;branch=${KBRANCH};"
 SRC_URI_prepend = "git://github.com/projectacrn/acrn-kernel.git;protocol=https;name=machine;branch=${KBRANCH};"
 
-LINUX_VERSION = "5.4.73"
-SRCREV_machine = "0dad2fa8edcbe288a1737d485959c5800caa47a7"
+LINUX_VERSION = "5.4.90"
+SRCREV_machine = "07fb8047e3dc1852881fc6dd6be12f11083d46f1"


### PR DESCRIPTION
update acrn-kernel SRCREV to version 5.4.90
Signed-off-by: wenlingz <wenling.zhang@intel.com>