### PR TITLE
acrn: update to tag acrn-2021w14.5-180000p

### DIFF
--- a/recipes-core/acrn/acrn-common.inc
+++ b/recipes-core/acrn/acrn-common.inc
@@ -9,7 +9,7 @@ SRC_URI = "git://github.com/projectacrn/acrn-hypervisor.git;branch=${SRCBRANCH};
 # Snapshot tags are of the format:
 # acrn-<year>w<week>.<day>-<timestamp><pass|fail>
 PV = "2.4"
-SRCREV = "b33c4181329d68f46338afc3f623df27bee2033f"
+SRCREV = "3991c48284c11b2e80fb144870b7c86bcd09b89b"
 SRCBRANCH = "release_2.4"
 
 UPSTREAM_CHECK_GITTAGREGEX = "^v(?P<pver>\d+(\.\d+)+)$"


### PR DESCRIPTION
Updated to RC6 release.

Update includes:
DM: gvt: Identical mapping for GPU DSM refine to support EHL/TGL
hv: Save/restore MSR_IA32_CSTAR during context switch
config-tools: modify sample launch scripts

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>