### PR TITLE
core-image-base-package: update launch script

### DIFF
--- a/recipes-guests/yocto/core-image-base-package/launch-base.sh
+++ b/recipes-guests/yocto/core-image-base-package/launch-base.sh
@@ -25,11 +25,6 @@ fi
 #logger_setting, format: logger_name,level; like following
 logger_setting="--logger_setting console,level=4;kmsg,level=3;disk,level=5"
 
-#for pm by vuart setting
-pm_channel="--pm_notify_channel uart "
-pm_by_vuart="--pm_by_vuart pty,/run/acrn/life_mngr_"$vm_name
-pm_vuart_node=" -s 1:0,lpc -l com2,/run/acrn/life_mngr_"$vm_name
-
 #for memsize setting
 mem_size=2048M
 
@@ -40,7 +35,6 @@ acrn-dm -A -m $mem_size -s 0:0,hostbridge \
   -s 4,virtio-net,tap0 \
   -s 7,virtio-rnd \
   --ovmf /usr/share/acrn/bios/OVMF.fd \
-  $pm_channel $pm_by_vuart $pm_vuart_node \
   $logger_setting \
   --mac_seed $mac_seed \
   $vm_name

--- a/recipes-guests/yocto/core-image-sato-package/launch-sato.sh
+++ b/recipes-guests/yocto/core-image-sato-package/launch-sato.sh
@@ -24,11 +24,6 @@ fi
 #logger_setting, format: logger_name,level; like following
 logger_setting="--logger_setting console,level=4;kmsg,level=3;disk,level=5"
 
-#for pm by vuart setting
-pm_channel="--pm_notify_channel uart "
-pm_by_vuart="--pm_by_vuart pty,/run/acrn/life_mngr_"$vm_name
-pm_vuart_node=" -s 1:0,lpc -l com2,/run/acrn/life_mngr_"$vm_name
-
 #for memsize setting
 mem_size=2048M
 
@@ -40,7 +35,6 @@ acrn-dm -A -m $mem_size  -s 0:0,hostbridge \
   -s 4,virtio-net,tap0 \
   -s 7,virtio-rnd \
   --ovmf /usr/share/acrn/bios/OVMF.fd \
-  $pm_channel $pm_by_vuart $pm_vuart_node \
   $logger_setting \
   --mac_seed $mac_seed \
   $vm_name

--- a/recipes-guests/yocto/core-image-weston-package/launch-weston.sh
+++ b/recipes-guests/yocto/core-image-weston-package/launch-weston.sh
@@ -24,11 +24,6 @@ fi
 #logger_setting, format: logger_name,level; like following
 logger_setting="--logger_setting console,level=4;kmsg,level=3;disk,level=5"
 
-#for pm by vuart setting
-pm_channel="--pm_notify_channel uart "
-pm_by_vuart="--pm_by_vuart pty,/run/acrn/life_mngr_"$vm_name
-pm_vuart_node=" -s 1:0,lpc -l com2,/run/acrn/life_mngr_"$vm_name
-
 #for memsize setting
 mem_size=2048M
 
@@ -40,7 +35,6 @@ acrn-dm -A -m $mem_size -s 0:0,hostbridge \
   -s 4,virtio-net,tap0 \
   -s 7,virtio-rnd \
   --ovmf /usr/share/acrn/bios/OVMF.fd \
-  $pm_channel $pm_by_vuart $pm_vuart_node \
   $logger_setting \
   --mac_seed $mac_seed \
   $vm_name


### PR DESCRIPTION
Ref:
https://github.com/projectacrn/acrn-hypervisor/commit/9e4fd1f1193353c5ef5043677663b9628eb8a240

As per commit:
Remove the Power Management ('pm') parameters from the sample launch scripts.
At most one VM is allowed to use "--pm_notify_channel uart"
at a time, since only one socket connection to SOS life_mngr is allowed.
Remove it by default and allow user to add on demand.

Also updated for:
core-image-sato-package
core-image-weston-package

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>