### PR TITLE
container-package: fix mcdepends, if multiconfig for sos not used

### DIFF
--- a/classes/container-package.bbclass
+++ b/classes/container-package.bbclass
@@ -16,7 +16,9 @@ IMAGE_NAME := "${@d.getVar('PN').replace('-package', '')}"
 # Where to install the image
 containerdir ?= "${localstatedir}/lib/machines"
 
-do_install[mcdepends] += "multiconfig:${BB_CURRENT_MC}:${CONTAINER_PACKAGE_MC}:${IMAGE_NAME}:do_image_complete"
+# multiconfig build
+ACRN_CURRENT_MC = "${@ "" if (d.getVar("BB_CURRENT_MC") == "default") else d.getVar("BB_CURRENT_MC") }"
+do_install[mcdepends] += "multiconfig:${ACRN_CURRENT_MC}:${CONTAINER_PACKAGE_MC}:${IMAGE_NAME}:do_image_complete"
 
 do_install () {
 	install -d ${D}${containerdir}


### PR DESCRIPTION
Issue can be reproduced, by building SOS without multiconfig.

ERROR: core-image-sato-package-1.0-r0 do_install: Execution of
'build/master-acrn-sos/work/intel_corei7_64-oe-linux/core-image-sato-package/1.0-r0/temp/run.do_install.69656'
failed with exit code 1: install: cannot stat
'build/master-acrn-uos/deploy/images/intel-corei7-64/core-image-sato-intel-corei7-64.wic': No such file or directory

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>