### PR TITLE
Backport kernel updates and bug fix to gatesgarth 

### DIFF
--- a/recipes-kernel/linux/linux-intel-acrn-sos_5.4.bb
+++ b/recipes-kernel/linux/linux-intel-acrn-sos_5.4.bb
@@ -1,6 +1,9 @@
 require linux-intel-acrn_5.4.inc
 
-SRC_URI_append = "  file://sos_5.4.scc"
+SRC_URI_append = " ${@bb.utils.contains('ACRN_BOARD', \
+                    'ehl-crb-b', bb.utils.contains('ACRN_SCENARIO', 'hybrid_rt_fusa', 'file://sos_5.4_hybrid_rt_fusa.scc', '', d), \
+                    '', d)} \
+                   file://sos_5.4.scc"
 
 LINUX_VERSION_EXTENSION = "-linux-intel-acrn-sos"
 
@@ -8,17 +11,11 @@ SUMMARY = "Linux Kernel with ACRN enabled (SOS)"
 
 KERNEL_FEATURES_append = "features/criu/criu-enable.scc \
                           cgl/cfg/iscsi.scc \
+                          ${@bb.utils.contains('ACRN_BOARD', 'ehl-crb-b', \
+                            bb.utils.contains('ACRN_SCENARIO', 'hybrid_rt_fusa', 'sos_5.4_hybrid_rt_fusa.scc', '', d), '', d)} \
                           sos_5.4.scc \
 "
 
 # sos_5.4.scc override CONFIG_REFCOUNT_FULL set in security.scc is causing warning during
 # config audit. Suppress this harmless warning.
 KCONF_AUDIT_LEVEL = "0"
-
-SRC_URI_append = " ${@get_scenario_cfg(d)}"
-
-def get_scenario_cfg(d):
-    if bb.utils.contains('ACRN_BOARD', 'ehl-crb-b', True, False, d):
-        if bb.utils.contains('ACRN_SCENARIO', 'hybrid_rt_fusa', True, False, d):
-            return 'file://sos_5.4_hybrid_rt.scc'
-    return ''

--- a/recipes-kernel/linux/linux-intel-acrn_5.4.inc
+++ b/recipes-kernel/linux/linux-intel-acrn_5.4.inc
@@ -9,9 +9,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 KBRANCH = "5.4/yocto"
 KMETA_BRANCH = "yocto-5.4"
 
-LINUX_VERSION ?= "5.4.96"
-SRCREV_machine ?= "a649a51485b7fc810a15ae44a0b393d4e4b91392"
-SRCREV_meta ?= "4f6d6c23cc8ca5d9c39b1efc2619b1dfec1ef2bc"
+LINUX_VERSION ?= "5.4.106"
+SRCREV_machine ?= "4dbe3697c9b89500917d5b6ff3a42b7af769de00"
+SRCREV_meta ?= "19738ca97b999a3b150e2d34232bb44b6537348f"
 
 DEPENDS += "elfutils-native openssl-native util-linux-native"
 

--- a/recipes-kernel/linux/linux-intel-rt-acrn-uos_5.4.bb
+++ b/recipes-kernel/linux/linux-intel-rt-acrn-uos_5.4.bb
@@ -20,9 +20,9 @@ KMETA_BRANCH = "yocto-5.4"
 
 DEPENDS += "elfutils-native openssl-native util-linux-native"
 
-LINUX_VERSION ?= "5.4.93"
-SRCREV_machine ?= "6d57e4c1caf4b50e55d27251a39312fec10cd870"
-SRCREV_meta ?= "4f6d6c23cc8ca5d9c39b1efc2619b1dfec1ef2bc"
+LINUX_VERSION ?= "5.4.102"
+SRCREV_machine ?= "7bbaa89ee7f0cb8e912e52b17247d0c0a7b2db15"
+SRCREV_meta ?= "19738ca97b999a3b150e2d34232bb44b6537348f"
 
 LINUX_VERSION_EXTENSION = "-linux-intel-preempt-rt-acrn-uos"
 


### PR DESCRIPTION
linux-intel-acrn-sos: fix scc filename typo
linux-intel-rt-acrn-uos/5.4: update to v5.4.102
linux-intel-acrn/5.4: update to 5.4.106
