### PR TITLE
fix acrn-libvirt failure

### DIFF
--- a/conf/distro/acrn-demo-sos.conf
+++ b/conf/distro/acrn-demo-sos.conf
@@ -11,6 +11,12 @@ PREFERRED_PROVIDER_libvirt = "acrn-libvirt"
 PREFERRED_PROVIDER_libvirt-native = "acrn-libvirt-native"
 PREFERRED_PROVIDER_nativesdk-libvirt = "nativesdk-acrn-libvirt"
 
+# acrn-libvirt (v6.1.0) is not supported by python3-docutil v0.17 and higher
+# python3-docutils (v0.16) recipe from this layer should be dropped with
+# acrn-libvirt upgrade
+PREFERRED_VERSION_python3-docutils = "0.16"
+PREFERRED_VERSION_python3-docutils-native = "0.16"
+
 
 # ACRN hypervisor log setting, sensible defaults
 LINUX_ACRN_APPEND ?= "hvlog=2M@0xE00000 ${@bb.utils.contains('EFI_PROVIDER','grub-efi','memmap=2M\$0xE00000','memmap=2M$0xE00000',d)} "

--- a/dynamic-layers/virtualization-layer/recipes-extended/libvirt/libvirt-python.inc
+++ b/dynamic-layers/virtualization-layer/recipes-extended/libvirt/libvirt-python.inc
@@ -1,4 +1,4 @@
-inherit python3native python3-dir
+inherit python3native python3-dir python3targetconfig
 
 export STAGING_INCDIR
 export STAGING_LIBDIR
@@ -24,11 +24,6 @@ export LIBVIRT_API_PATH = "${S}/docs/libvirt-api.xml"
 export LIBVIRT_CFLAGS = "-I${S}/include"
 export LIBVIRT_LIBS = "-L${B}/src/.libs -lvirt -ldl"
 export LDFLAGS="-L${B}/src/.libs"
-
-export LDSHARED  = "${CCLD} -shared"
-export LDCXXSHARED  = "${CXX} -shared"
-export CCSHARED  = "-fPIC -DPIC"
-export LINKFORSHARED = "${SECURITY_CFLAGS} -Xlinker -export-dynamic"
 
 LIBVIRT_INSTALL_ARGS = "--root=${D} \
     --prefix=${prefix} \

--- a/recipes-devtools/python/python3-docutils_0.16.bb
+++ b/recipes-devtools/python/python3-docutils_0.16.bb
@@ -1,0 +1,12 @@
+SUMMARY = "Docutils is a modular system for processing documentation into useful formats"
+HOMEPAGE = "https://pypi.org/project/docutils/"
+SECTION = "devel/python"
+LICENSE = "BSD-2-Clause & GPL-2.0 & Python-2.0"
+LIC_FILES_CHKSUM = "file://COPYING.txt;md5=7a4646907ab9083c826280b19e103106"
+
+SRC_URI[md5sum] = "9ccb6f332e23360f964de72c8ea5f0ed"
+SRC_URI[sha256sum] = "7d4e999cca74a52611773a42912088078363a30912e8822f7a3d38043b767573"
+
+inherit pypi setuptools3
+
+BBCLASSEXTEND = "native"


### PR DESCRIPTION
python3-docutils: add recipe

acrn-libvirt v6.1.0, does not build with python-docutils v0.17 and higher.
This recipe will be removed once acrn-libvirt is fixed (or upgraded) for python-docutils v0.17.

######################################################################
libvirt-python: inherit python3targetconfig

libvirt shouldn't be using host's gcc to build python module, this issue
is caused by missing inherit of python3targetconfig instead added in:
https://git.openembedded.org/openembedded-core/commit/?id=5a118d4e7985fa88f04c3611f8db813f0dafce75

* otherwise libvirt build will incorrectly use host's gcc and fail with:
gcc: error: unrecognized command line option "-fmacro-prefix-map=/OE/libvirt/6.1.0-r0=/usr/src/debug/libvirt/6.1.0-r0"

This reverts commit : https://github.com/intel/meta-acrn/commit/3a5415263bfb033766ed3e7283cc5753f5eff1dd


Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>
