### PR TITLE
acrn: update to tag acrn-2021w21.4-180000p

### DIFF
--- a/recipes-core/acrn/acrn-common.inc
+++ b/recipes-core/acrn/acrn-common.inc
@@ -9,7 +9,7 @@ SRC_URI = "git://github.com/projectacrn/acrn-hypervisor.git;branch=${SRCBRANCH};
 # Snapshot tags are of the format:
 # acrn-<year>w<week>.<day>-<timestamp><pass|fail>
 PV = "2.5"
-SRCREV = "688a41c29041d67f5ceda8c3754a50111a95b8d6"
+SRCREV = "5df3455e8dcca8cc00fc5a3acdf14c84f55e1fc5"
 SRCBRANCH = "master"
 
 UPSTREAM_CHECK_GITTAGREGEX = "^v(?P<pver>\d+(\.\d+)+)$"


### PR DESCRIPTION
updated with the ACRN daily tag acrn-2021w21.4-180000p

It has fix for gcc-11 build failures [1].

[1] https://github.com/projectacrn/acrn-hypervisor/commit/1e033f9d89f5cd5f3f6799359b00089ee1b3ed8b

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>