### PR TITLE
acrn: add efi-stub feature for booting sbl_os on uefi systems

### DIFF
--- a/docs/slimbootloader.md
+++ b/docs/slimbootloader.md
@@ -104,3 +104,8 @@ bzImage bzImage-5.4.52-linux-intel-acrn-sos EFI loader sbl_os
 * BB_CURRENT_MC
   Get the Current Configuration using this variable when multiple configuration have specified in conf/local.conf using BBMULTICONFIG variable.
   Example: currentMultibootConfig = d.getVar('BB_CURRENT_MC')
+
+* ACRN_FIRMWARE
+  Set ACRN_FIRMWARE="uefi" in your sos multiconfig file (Example: conf/multiconfig/sos.conf) to generate the ACRN EFI application which allows to boot your sbl_os image on UEFI-BIOS systems.
+  See the "Enable ACRN Secure Boot With EFI-Stub" page on the "Project ACRN Documentation" for the details.
+  The acrn.efi file will be generated in the deployment directory (Example: master-acrn-sos/deploy/images/intel-corei7-64/acrn.efi)

--- a/recipes-core/acrn/acrn-common.inc
+++ b/recipes-core/acrn/acrn-common.inc
@@ -9,8 +9,8 @@ SRC_URI = "git://github.com/projectacrn/acrn-hypervisor.git;branch=${SRCBRANCH};
 # Snapshot tags are of the format:
 # acrn-<year>w<week>.<day>-<timestamp><pass|fail>
 PV = "2.5"
-SRCREV = "5df3455e8dcca8cc00fc5a3acdf14c84f55e1fc5"
-SRCBRANCH = "master"
+SRCREV = "3d7345249380aff9fe338d885c84c842902808f2"
+SRCBRANCH = "release_2.5"
 
 UPSTREAM_CHECK_GITTAGREGEX = "^v(?P<pver>\d+(\.\d+)+)$"
 


### PR DESCRIPTION
The new efi-stub introduced to ACRN v2.5 allows booting a Slim Bootloader
Container Boot Image on UEFI-BIOS systems. Updated the recipe to generate a
boot image namely acrn.efi which combines the efi-stub application and the
sbl_os image, when both the 'acrn-sblimage' class and the 'uefi' ACRN_FIRMWARE
type is selected.

Note that the feature is only available in the ACRN 'release_2.5' branch but
not in the 'master' branch. Due to that now the 'acrn-common.inc' points to the
'release_2.5' branch.

Signed-off-by: Toshiki Nishioka <toshiki.nishioka@intel.com>