### PR TITLE
Master backport

### DIFF
--- a/docs/slimbootloader.md
+++ b/docs/slimbootloader.md
@@ -104,3 +104,8 @@ bzImage bzImage-5.4.52-linux-intel-acrn-sos EFI loader sbl_os
 * BB_CURRENT_MC
   Get the Current Configuration using this variable when multiple configuration have specified in conf/local.conf using BBMULTICONFIG variable.
   Example: currentMultibootConfig = d.getVar('BB_CURRENT_MC')
+
+* ACRN_FIRMWARE
+  Set ACRN_FIRMWARE="uefi" in your sos multiconfig file (Example: conf/multiconfig/sos.conf) to generate the ACRN EFI application which allows to boot your sbl_os image on UEFI-BIOS systems.
+  See the "Enable ACRN Secure Boot With EFI-Stub" page on the "Project ACRN Documentation" for the details.
+  The acrn.efi file will be generated in the deployment directory (Example: master-acrn-sos/deploy/images/intel-corei7-64/acrn.efi)

--- a/recipes-core/acrn/acrn-hypervisor.bb
+++ b/recipes-core/acrn/acrn-hypervisor.bb
@@ -2,6 +2,7 @@ require acrn-common.inc
 
 ACRN_BOARD ?= "nuc7i7dnb"
 ACRN_SCENARIO  ?= "industry"
+ACRN_CONFIG_PATCH ?= ""
 
 EXTRA_OEMAKE += "HV_OBJDIR=${B}/hypervisor "
 EXTRA_OEMAKE += "BOARD=${ACRN_BOARD} SCENARIO=${ACRN_SCENARIO}"
@@ -17,6 +18,19 @@ DEPENDS += "acrn-hypervisor-native acpica-native python3-lxml-native"
 # parallel build could face build failure in case of config-tool method:
 #    | .config does not exist and no defconfig available for BOARD...
 PARALLEL_MAKE = ""
+
+do_configure_class-target() {
+	# generate configuration and patch it when the configuration patch file is valid
+	# clang-format are not supported at this point, hence the patch file to use should not generate with clang-format
+	if [ -n "${ACRN_CONFIG_PATCH}" ]; then
+		if [ -f "${ACRN_CONFIG_PATCH}" ]; then
+			oe_runmake hvdefconfig
+			oe_runmake hvapplydiffconfig PATCH=${ACRN_CONFIG_PATCH}
+		else
+			bberror "ACRN_CONFIG_PATCH are set to ${ACRN_CONFIG_PATCH} but the file not found"
+		fi
+	fi
+}
 
 do_compile_class-target() {
 	# Execute natively build sanity check for ACRN configurations

--- a/recipes-kernel/linux/linux-intel-acrn_5.4.inc
+++ b/recipes-kernel/linux/linux-intel-acrn_5.4.inc
@@ -9,8 +9,8 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 KBRANCH = "5.4/yocto"
 KMETA_BRANCH = "yocto-5.4"
 
-LINUX_VERSION ?= "5.4.115"
-SRCREV_machine ?= "e7c4b07f6a81135951d7855d798aaf057b78e2e7"
+LINUX_VERSION ?= "5.4.123"
+SRCREV_machine ?= "8439b417c99e532625e316274231a491af734201"
 SRCREV_meta ?= "76aa6f85d62f7fc05c4b3e371fafe74290fc2238"
 
 DEPENDS += "elfutils-native openssl-native util-linux-native"

--- a/recipes-kernel/linux/linux-intel-rt-acrn-uos_5.4.bb
+++ b/recipes-kernel/linux/linux-intel-rt-acrn-uos_5.4.bb
@@ -20,8 +20,8 @@ KMETA_BRANCH = "yocto-5.4"
 
 DEPENDS += "elfutils-native openssl-native util-linux-native"
 
-LINUX_VERSION ?= "5.4.115"
-SRCREV_machine ?= "00c7e2e1841e0ed3c1249c0e4bcacbd70435d62e"
+LINUX_VERSION ?= "5.4.123"
+SRCREV_machine ?= "31aebc6b6377591f43c127ccd9230ea01afb0a76"
 SRCREV_meta ?= "76aa6f85d62f7fc05c4b3e371fafe74290fc2238"
 
 LINUX_VERSION_EXTENSION = "-linux-intel-preempt-rt-acrn-uos"


### PR DESCRIPTION
    acrn: add efi-stub feature for booting sbl_os on uefi systems

    The new efi-stub introduced to ACRN v2.5 allows booting a Slim Bootloader
    Container Boot Image on UEFI-BIOS systems. Updated the recipe to generate a
    boot image namely acrn.efi which combines the efi-stub application and the
    sbl_os image, when both the 'acrn-sblimage' class and the 'uefi' ACRN_FIRMWARE
    type is selected.

    Note that the feature is only available in the ACRN 'release_2.5' branch but
    not in the 'master' branch. Due to that now the 'acrn-common.inc' points to the
    'release_2.5' branch.

    Signed-off-by: Toshiki Nishioka <toshiki.nishioka@intel.com>
    Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>
=================================================================

    acrn: add feature to patch configuration

    we can now generate the configuration and patch it before build it.
    As this is not patching the original source code it does not work with
    SRC_URI, so add a new variable ACRN_CONFIG_PATCH to point to the patch file.

    add it to local.conf to apply the patch to the configuration:
    ACRN_CONFIG_PATCH = "/path/to/config.patch"

    without clang-format, patch file generated with clang-format would not
    work at this point.

    reference:
    https://projectacrn.github.io/latest/tutorials/acrn_configuration_tool.html#makefile-targets-for-configuration

    Signed-off-by: Lee Chee Yang <chee.yang.lee@intel.com>
================================================================
    linux-intel-rt-acrn-uos: update to v5.4.123

    update to lts-v5.4.123-yocto-210623T011824Z

    Signed-off-by: Lee Chee Yang <chee.yang.lee@intel.com>
===============================================================
    linux-intel-acrn: update to 5.4.123

    update to lts-v5.4.123-yocto-210624T085337Z

    Signed-off-by: Lee Chee Yang <chee.yang.lee@intel.com>


