### PR TITLE
acrn: update to tag v2.5

### DIFF
--- a/recipes-core/acrn/acrn-common.inc
+++ b/recipes-core/acrn/acrn-common.inc
@@ -9,7 +9,7 @@ SRC_URI = "git://github.com/projectacrn/acrn-hypervisor.git;branch=${SRCBRANCH};
 # Snapshot tags are of the format:
 # acrn-<year>w<week>.<day>-<timestamp><pass|fail>
 PV = "2.5"
-SRCREV = "25fa3466c52ed7402662b98989bb6781648c6c6d"
+SRCREV = "2b913c39e61e11f4534cf8b17b79fd5546e9944b"
 SRCBRANCH = "release_2.5"
 
 UPSTREAM_CHECK_GITTAGREGEX = "^v(?P<pver>\d+(\.\d+)+)$"


### PR DESCRIPTION
This update include following commits:
02350da92 doc: update known issues in 2.5 release notes
2b913c39e version:v2.5
cd4dc73ca doc: push doc updates for v2.5 release
7e9d62542 config_tools: remove nuc11tnbi5 scenario xml except industry.xml

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>