### PR TITLE
Remove uart=mmio@0xfe042000 in the acrn-sblimage.bbclass

### DIFF
--- a/classes/acrn-sblimage.bbclass
+++ b/classes/acrn-sblimage.bbclass
@@ -25,7 +25,7 @@ python do_acrn_sblimage() {
     if mbAcrnCmdlineDeployDir == "":
         hv_cmdline = d.getVar('WORKDIR') + "/hv_cmdline"
         bb.debug(1, "hv_cmdline: %s" % (hv_cmdline))
-        subprocess.check_call("echo 'uart=mmio@0xfe042000' > %s" % (hv_cmdline), shell=True)
+        subprocess.check_call("echo '' > %s" % (hv_cmdline), shell=True)
     else:
         hv_cmdline = mbAcrnCmdlineDeployDir
 


### PR DESCRIPTION
The EHL uart at mmio 0xfe042000 has been defined in ehl-crb-b board file as ttyS3, so it is not needed to specify this mmio uart as hv console in hv cmdline when the ttyS3 is specified as hv console in scenario file, otherwise the hv console would be overridden when other uart is chosen as hv console.

Signed-off-by: wenlingz <wenling.zhang@intel.com>