### PR TITLE
acrn: upgrade to v2.6-unstable

### DIFF
--- a/recipes-core/acrn/acrn-common.inc
+++ b/recipes-core/acrn/acrn-common.inc
@@ -8,9 +8,9 @@ SRC_URI = "git://github.com/projectacrn/acrn-hypervisor.git;branch=${SRCBRANCH};
 
 # Snapshot tags are of the format:
 # acrn-<year>w<week>.<day>-<timestamp><pass|fail>
-PV = "2.5"
-SRCREV = "e5aa63b08eb6bff4e40b1c3468cd010c56fbbce7"
-SRCBRANCH = "release_2.5"
+PV = "2.6"
+SRCREV = "20061b7c391d6a113d459f002737214c0486005b"
+SRCBRANCH = "master"
 
 UPSTREAM_CHECK_GITTAGREGEX = "^v(?P<pver>\d+(\.\d+)+)$"
 

--- a/recipes-core/acrn/acrn-hypervisor/hypervisor-dont-build-pre_build.patch
+++ b/recipes-core/acrn/acrn-hypervisor/hypervisor-dont-build-pre_build.patch
@@ -1,6 +1,6 @@
-From c1437266a067e67bafcf8c89ecf54e2464cff233 Mon Sep 17 00:00:00 2001
+From 38806dce4e306862bb21a63697734fffaa67e02b Mon Sep 17 00:00:00 2001
 From: Naveen Saini <naveen.kumar.saini@intel.com>
-Date: Thu, 5 Aug 2021 11:26:39 +0800
+Date: Mon, 9 Aug 2021 18:00:50 +0800
 Subject: [PATCH] Execute pre_build_check during hypervisor build is causing
  error
 
@@ -16,10 +16,10 @@ Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>
  1 file changed, 3 deletions(-)
 
 diff --git a/hypervisor/Makefile b/hypervisor/Makefile
-index b11988cde..2da40fd2a 100644
+index 85af66b81..52edd6c89 100644
 --- a/hypervisor/Makefile
 +++ b/hypervisor/Makefile
-@@ -394,9 +394,6 @@ install-debug: $(HV_OBJDIR)/$(HV_FILE).map $(HV_OBJDIR)/$(HV_FILE).out
+@@ -391,9 +391,6 @@ install-debug: $(HV_OBJDIR)/$(HV_FILE).map $(HV_OBJDIR)/$(HV_FILE).out
  
  .PHONY: pre_build
  pre_build: $(HV_CONFIG_H) $(HV_CONFIG_TIMESTAMP)
@@ -27,7 +27,7 @@ index b11988cde..2da40fd2a 100644
 -	$(MAKE) -C $(PRE_BUILD_DIR) BOARD=$(BOARD) SCENARIO=$(SCENARIO) TARGET_DIR=$(HV_CONFIG_DIR)
 -	@$(HV_OBJDIR)/hv_prebuild_check.out
  	@echo "generate the binary of ACPI tables for pre-launched VMs ..."
- 	python3 ../misc/config_tools/acpi_gen/bin_gen.py --board $(HV_OBJDIR)/.board.xml --scenario $(HV_OBJDIR)/.scenario.xml --asl $(HV_CONFIG_DIR) --out $(HV_OBJDIR)
+ 	python3 ../misc/config_tools/acpi_gen/bin_gen.py --board $(BOARD) --scenario $(SCENARIO) --asl $(HV_CONFIG_DIR) --out $(HV_OBJDIR)/acpi
  
 -- 
 2.17.1

--- a/recipes-kernel/linux/acrn-kernel_5.10.inc
+++ b/recipes-kernel/linux/acrn-kernel_5.10.inc
@@ -13,8 +13,8 @@ KBRANCH = "master"
 KMETA_BRANCH = "yocto-5.10"
 
 
-LINUX_VERSION = "5.10.47"
-SRCREV_machine = "dd0976bd67fd8d14c44f4bc5b8d63892a1c53f66"
+LINUX_VERSION = "5.10.52"
+SRCREV_machine = "a827327e71e9b9bbedaf68780c799f0a6f597c28"
 SRCREV_meta = "eb09284047fec2f09d62068c338ae320c6681bd1"
 
 DEPENDS += "elfutils-native openssl-native util-linux-native"


### PR DESCRIPTION
Tag: acrn-2021w33.2-180000p
https://github.com/projectacrn/acrn-hypervisor/releases/tag/acrn-2021w33.2-180000p

acrn-kernel/5.10: update to 5.10.52