### PR TITLE
acrn: update to tag acrn-2021w33.5-180000p

### DIFF
--- a/recipes-core/acrn/acrn-common.inc
+++ b/recipes-core/acrn/acrn-common.inc
@@ -9,7 +9,7 @@ SRC_URI = "git://github.com/projectacrn/acrn-hypervisor.git;branch=${SRCBRANCH};
 # Snapshot tags are of the format:
 # acrn-<year>w<week>.<day>-<timestamp><pass|fail>
 PV = "2.6"
-SRCREV = "20061b7c391d6a113d459f002737214c0486005b"
+SRCREV = "668ae810480ea29013c81e56739eef916095a31d"
 SRCBRANCH = "master"
 
 UPSTREAM_CHECK_GITTAGREGEX = "^v(?P<pver>\d+(\.\d+)+)$"

--- a/recipes-core/acrn/acrn-hypervisor.bb
+++ b/recipes-core/acrn/acrn-hypervisor.bb
@@ -14,7 +14,7 @@ inherit python3native deploy
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
-DEPENDS += "acrn-hypervisor-native acpica-native python3-lxml-native gnu-efi"
+DEPENDS += "acrn-hypervisor-native acpica-native python3-lxml-native gnu-efi python3-defusedxml-native"
 
 # parallel build could face build failure in case of config-tool method:
 #    | .config does not exist and no defconfig available for BOARD...

--- a/recipes-core/acrn/acrn-hypervisor/hypervisor-dont-build-pre_build.patch
+++ b/recipes-core/acrn/acrn-hypervisor/hypervisor-dont-build-pre_build.patch
@@ -1,6 +1,6 @@
-From 38806dce4e306862bb21a63697734fffaa67e02b Mon Sep 17 00:00:00 2001
+From b4ebadc216cc81e81edfe10cd0643429aa76bbee Mon Sep 17 00:00:00 2001
 From: Naveen Saini <naveen.kumar.saini@intel.com>
-Date: Mon, 9 Aug 2021 18:00:50 +0800
+Date: Tue, 17 Aug 2021 11:25:10 +0800
 Subject: [PATCH] Execute pre_build_check during hypervisor build is causing
  error
 
@@ -16,7 +16,7 @@ Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>
  1 file changed, 3 deletions(-)
 
 diff --git a/hypervisor/Makefile b/hypervisor/Makefile
-index 85af66b81..52edd6c89 100644
+index 1e70bb5e0..ee1ae9920 100644
 --- a/hypervisor/Makefile
 +++ b/hypervisor/Makefile
 @@ -391,9 +391,6 @@ install-debug: $(HV_OBJDIR)/$(HV_FILE).map $(HV_OBJDIR)/$(HV_FILE).out
@@ -27,7 +27,7 @@ index 85af66b81..52edd6c89 100644
 -	$(MAKE) -C $(PRE_BUILD_DIR) BOARD=$(BOARD) SCENARIO=$(SCENARIO) TARGET_DIR=$(HV_CONFIG_DIR)
 -	@$(HV_OBJDIR)/hv_prebuild_check.out
  	@echo "generate the binary of ACPI tables for pre-launched VMs ..."
- 	python3 ../misc/config_tools/acpi_gen/bin_gen.py --board $(BOARD) --scenario $(SCENARIO) --asl $(HV_CONFIG_DIR) --out $(HV_OBJDIR)/acpi
+ 	python3 ../misc/config_tools/acpi_gen/bin_gen.py --board $(HV_OBJDIR)/.board.xml --scenario $(HV_OBJDIR)/.scenario.xml --asl $(HV_CONFIG_DIR) --out $(HV_OBJDIR)
  
 -- 
 2.17.1

--- a/recipes-devtools/python/python3-defusedxml_%.bbappend
+++ b/recipes-devtools/python/python3-defusedxml_%.bbappend
@@ -1,0 +1,1 @@
+BBCLASSEXTEND = "native"


### PR DESCRIPTION
ACRN release_2.6 RC1.

python3-defusedxml: add bbappend
Extend recipe to add native support.

It is new dependency introduced by:
https://github.com/projectacrn/acrn-hypervisor/pull/6343/files

This bbappend should be droped once following patch is merged upstream.
https://lists.openembedded.org/g/openembedded-devel/message/92535

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>