### PR TITLE
acrn: fix build failure with e2fsprogs v1.46.2

### DIFF
--- a/recipes-core/acrn/acrn-common.inc
+++ b/recipes-core/acrn/acrn-common.inc
@@ -4,6 +4,7 @@ LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b762ef53db85c389256a9d215053edf7"
 
 SRC_URI = "git://github.com/projectacrn/acrn-hypervisor.git;branch=${SRCBRANCH} \
+            file://0001-crashlog-fix-build-issue-with-e2fsprogs-v1.46.2.patch \
 "
 
 # Snapshot tags are of the format:

--- a/recipes-core/acrn/files/0001-crashlog-fix-build-issue-with-e2fsprogs-v1.46.2.patch
+++ b/recipes-core/acrn/files/0001-crashlog-fix-build-issue-with-e2fsprogs-v1.46.2.patch
@@ -1,0 +1,33 @@
+From e71b68c04ed7b5e0a6cc983600812785e947bb56 Mon Sep 17 00:00:00 2001
+From: Yin Fengwei <fengwei.yin@intel.com>
+Date: Thu, 26 Aug 2021 12:31:06 +0800
+Subject: [PATCH] crashlog: fix build issue with e2fsprogs v1.46.2
+
+In e2fsprogs v1.46.2, s_volume_name is defined with attribute
+nonstring. So strncmp instead of strcmp should be used to do
+comparing.
+
+Upstream-Status: Pending
+
+Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>
+Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>
+---
+ misc/debug_tools/acrn_crashlog/acrnprobe/loop.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/misc/debug_tools/acrn_crashlog/acrnprobe/loop.c b/misc/debug_tools/acrn_crashlog/acrnprobe/loop.c
+index ad6db22ba..ee27e4aa6 100644
+--- a/misc/debug_tools/acrn_crashlog/acrnprobe/loop.c
++++ b/misc/debug_tools/acrn_crashlog/acrnprobe/loop.c
+@@ -231,7 +231,7 @@ int loopdev_check_parname(const char *loopdev, const char *parname)
+ 		/* only look into the primary super block */
+ 		if (super.s_volume_name[0]) {
+ 			close(fd);
+-			return !strcmp((const char *)super.s_volume_name, parname);
++			return !strncmp((const char *)super.s_volume_name, parname, EXT2_LABEL_LEN);
+ 		}
+ 		break;
+ 	}
+-- 
+2.17.1
+


### PR DESCRIPTION
Patch applied.

Error log:
loop.c: In function 'loopdev_check_parname':
loop.c:234:33: error: 'strcmp' argument 1 declared attribute 'nonstring' [-Werror=stringop-overread]
  234 |                         return !strcmp((const char *)super.s_volume_name, parname);
      |

make[2]: Leaving directory '/home/pokybuild/yocto-autobuilder-new/yocto-worker/intel-corei7-64-acrn-image-sato-linux-intel-default-kernel/build/build/master-acrn-sos/work/corei7-64-oe-linux/acrn-tools/2.5-r0/git/misc/services/acrn_manager'
loop.c: In function 'loopdev_check_parname':
loop.c:234:33: error: 'strcmp' argument 1 declared attribute 'nonstring' [-Werror=stringop-overread]
  234 |                         return !strcmp((const char *)super.s_volume_name, parname);
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /home/pokybuild/yocto-autobuilder-new/yocto-worker/intel-corei7-64-acrn-image-sato-linux-intel-default-kernel/build/build/master-acrn-sos/work/corei7-64-oe-linux/acrn-tools/2.5-r0/recipe-sysroot/usr/include/ext2fs/ext2fs.h:84,
                 from loop.c:19:
/home/pokybuild/yocto-autobuilder-new/yocto-worker/intel-corei7-64-acrn-image-sato-linux-intel-default-kernel/build/build/master-acrn-sos/work/corei7-64-oe-linux/acrn-tools/2.5-r0/recipe-sysroot/usr/include/ext2fs/ext2_fs.h:699:17: note: argument 's_volume_name' declared here
  699 | /*078*/ __u8    s_volume_name[EXT2_LABEL_LEN] __nonstring;      /* volume name, no NUL? */
      |                 ^~~~~~~~~~~~~
cc1: all warnings being treated as errors

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>