### PR TITLE
linux-intel-acrn/5.4: update to v5.4.138

### DIFF
--- a/recipes-kernel/linux/linux-intel-acrn_5.4.inc
+++ b/recipes-kernel/linux/linux-intel-acrn_5.4.inc
@@ -9,9 +9,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 KBRANCH = "5.4/yocto"
 KMETA_BRANCH = "yocto-5.4"
 
-LINUX_VERSION ?= "5.4.106"
-SRCREV_machine ?= "4dbe3697c9b89500917d5b6ff3a42b7af769de00"
-SRCREV_meta ?= "19738ca97b999a3b150e2d34232bb44b6537348f"
+LINUX_VERSION ?= "5.4.115"
+SRCREV_machine ?= "e7c4b07f6a81135951d7855d798aaf057b78e2e7"
+SRCREV_meta ?= "76aa6f85d62f7fc05c4b3e371fafe74290fc2238"
 
 DEPENDS += "elfutils-native openssl-native util-linux-native"
 

--- a/recipes-kernel/linux/linux-intel-acrn_5.4.inc
+++ b/recipes-kernel/linux/linux-intel-acrn_5.4.inc
@@ -9,8 +9,8 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 KBRANCH = "5.4/yocto"
 KMETA_BRANCH = "yocto-5.4"
 
-LINUX_VERSION ?= "5.4.115"
-SRCREV_machine ?= "e7c4b07f6a81135951d7855d798aaf057b78e2e7"
+LINUX_VERSION ?= "5.4.123"
+SRCREV_machine ?= "8439b417c99e532625e316274231a491af734201"
 SRCREV_meta ?= "76aa6f85d62f7fc05c4b3e371fafe74290fc2238"
 
 DEPENDS += "elfutils-native openssl-native util-linux-native"

--- a/recipes-kernel/linux/linux-intel-acrn_5.4.inc
+++ b/recipes-kernel/linux/linux-intel-acrn_5.4.inc
@@ -9,9 +9,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 KBRANCH = "5.4/yocto"
 KMETA_BRANCH = "yocto-5.4"
 
-LINUX_VERSION ?= "5.4.123"
-SRCREV_machine ?= "8439b417c99e532625e316274231a491af734201"
-SRCREV_meta ?= "76aa6f85d62f7fc05c4b3e371fafe74290fc2238"
+LINUX_VERSION ?= "5.4.138"
+SRCREV_machine ?= "717625cb3aa634624a834500904d6fd54c73a7bf"
+SRCREV_meta ?= "70b2480497528245c948ec259c734d74ea4fa3f1"
 
 DEPENDS += "elfutils-native openssl-native util-linux-native"
 

--- a/recipes-kernel/linux/linux-intel-rt-acrn-uos_5.4.bb
+++ b/recipes-kernel/linux/linux-intel-rt-acrn-uos_5.4.bb
@@ -20,9 +20,9 @@ KMETA_BRANCH = "yocto-5.4"
 
 DEPENDS += "elfutils-native openssl-native util-linux-native"
 
-LINUX_VERSION ?= "5.4.123"
-SRCREV_machine ?= "31aebc6b6377591f43c127ccd9230ea01afb0a76"
-SRCREV_meta ?= "76aa6f85d62f7fc05c4b3e371fafe74290fc2238"
+LINUX_VERSION ?= "5.4.138"
+SRCREV_machine ?= "8b0e20e933dd76abff867deba81597e94f587921"
+SRCREV_meta ?= "70b2480497528245c948ec259c734d74ea4fa3f1"
 
 LINUX_VERSION_EXTENSION = "-linux-intel-preempt-rt-acrn-uos"
 

--- a/recipes-kernel/linux/linux-intel-rt-acrn-uos_5.4.bb
+++ b/recipes-kernel/linux/linux-intel-rt-acrn-uos_5.4.bb
@@ -20,8 +20,8 @@ KMETA_BRANCH = "yocto-5.4"
 
 DEPENDS += "elfutils-native openssl-native util-linux-native"
 
-LINUX_VERSION ?= "5.4.115"
-SRCREV_machine ?= "00c7e2e1841e0ed3c1249c0e4bcacbd70435d62e"
+LINUX_VERSION ?= "5.4.123"
+SRCREV_machine ?= "31aebc6b6377591f43c127ccd9230ea01afb0a76"
 SRCREV_meta ?= "76aa6f85d62f7fc05c4b3e371fafe74290fc2238"
 
 LINUX_VERSION_EXTENSION = "-linux-intel-preempt-rt-acrn-uos"

--- a/recipes-kernel/linux/linux-intel-rt-acrn-uos_5.4.bb
+++ b/recipes-kernel/linux/linux-intel-rt-acrn-uos_5.4.bb
@@ -20,9 +20,9 @@ KMETA_BRANCH = "yocto-5.4"
 
 DEPENDS += "elfutils-native openssl-native util-linux-native"
 
-LINUX_VERSION ?= "5.4.102"
-SRCREV_machine ?= "7bbaa89ee7f0cb8e912e52b17247d0c0a7b2db15"
-SRCREV_meta ?= "19738ca97b999a3b150e2d34232bb44b6537348f"
+LINUX_VERSION ?= "5.4.115"
+SRCREV_machine ?= "00c7e2e1841e0ed3c1249c0e4bcacbd70435d62e"
+SRCREV_meta ?= "76aa6f85d62f7fc05c4b3e371fafe74290fc2238"
 
 LINUX_VERSION_EXTENSION = "-linux-intel-preempt-rt-acrn-uos"
 


### PR DESCRIPTION
    linux-intel-rt-acrn-uos/5.4: update to v5.4.138

    Updates -rt patchset to -rt62.

    Updated config as well.

    Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>
