### PR TITLE
acrn-devicemodel: do not build tools

### DIFF
--- a/recipes-core/acrn/acrn-common.inc
+++ b/recipes-core/acrn/acrn-common.inc
@@ -10,7 +10,7 @@ SRC_URI = "git://github.com/projectacrn/acrn-hypervisor.git;branch=${SRCBRANCH};
 # Snapshot tags are of the format:
 # acrn-<year>w<week>.<day>-<timestamp><pass|fail>
 PV = "2.6"
-SRCREV = "77f9d871afad68ec29c2226da4e55e5cb21f1651"
+SRCREV = "f83d782255a38718f2151c0cd924553168f18911"
 SRCBRANCH = "release_2.6"
 
 UPSTREAM_CHECK_GITTAGREGEX = "^v(?P<pver>\d+(\.\d+)+)$"

--- a/recipes-core/acrn/acrn-devicemodel/dont-build-tools.patch
+++ b/recipes-core/acrn/acrn-devicemodel/dont-build-tools.patch
@@ -1,12 +1,38 @@
-No need to build the tools as we can use the libraries already installed.
+From 071de6ed6e2eb84eccedfb6d2ce32048ddb1e3ac Mon Sep 17 00:00:00 2001
+From: Naveen Saini <naveen.kumar.saini@intel.com>
+Date: Tue, 17 Aug 2021 14:52:42 +0800
+Subject: [PATCH] No need to build & install the tools as we can use the
+ libraries already installed.
 
 Upstream-Status: Inappropriate
-Signed-off-by: Ross Burton <ross.burton@intel.com>
+
+Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>
+---
+ Makefile | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/Makefile b/Makefile
-index f0bfd2d3..2440070c 100644
+index 808117ff..cc50052f 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -45 +45 @@ sbl-hypervisor:
+@@ -114,7 +114,7 @@ hvdiffconfig:
+ hvapplydiffconfig:
+ 	@$(MAKE) applydiffconfig $(HV_MAKEOPTS) PATCH=$(abspath $(PATCH))
+ 
 -devicemodel: tools
 +devicemodel:
+ 	$(MAKE) -C $(T)/devicemodel DM_OBJDIR=$(DM_OUT) DM_BUILD_VERSION=$(BUILD_VERSION) DM_BUILD_TAG=$(BUILD_TAG) DM_ASL_COMPILER=$(ASL_COMPILER) TOOLS_OUT=$(TOOLS_OUT) RELEASE=$(RELEASE)
+ 
+ tools:
+@@ -167,7 +167,7 @@ apl-up2-hybrid-install-debug:
+ sbl-hypervisor-install-debug: kbl-nuc-i7-industry-install-debug \
+ 			      apl-up2-hybrid-install-debug
+ 
+-devicemodel-install: tools-install devicemodel
++devicemodel-install: devicemodel
+ 	$(MAKE) -C $(T)/devicemodel DM_OBJDIR=$(DM_OUT) install
+ 
+ tools-install: tools
+-- 
+2.17.1
+


### PR DESCRIPTION
Tools are built using seperate recipe and made available
during devicemodel build using DEPENDS

Refreshed patch.

It also update recipe to include lastest commits:
f83d78225 hv: pci: fix a minor bug about is_pci_cfg_multifunction
1c61872ef dm: pci: minor bug fix about uninitialized local variable
0b63f3378 Makefile: add missing deps in top-level and hypervisor Makefile

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>