### PR TITLE
config: modify kernel physical start address

### DIFF
--- a/recipes-kernel/linux/files/sos.cfg
+++ b/recipes-kernel/linux/files/sos.cfg
@@ -24,7 +24,6 @@ CONFIG_OPENVSWITCH=m
 
 
 # Let SOS kernel start from higher address to avoid its memory conflict with grub modules
-CONFIG_PHYSICAL_START=0x8000000
 CONFIG_IOMMU_SUPPORT=n
 CONFIG_INTEL_IOMMU=n
 


### PR DESCRIPTION
From ACRN release 2.5,hypervisor supports relocate kernel
 to the guest free space. So specify the kernel physical
 start address is not needed any more

Signed-off-by: wenlingz <wenling.zhang@intel.com>