### PR TITLE
Master next update

### DIFF
--- a/recipes-kernel/linux/acrn-kernel-uos_5.10.bb
+++ b/recipes-kernel/linux/acrn-kernel-uos_5.10.bb
@@ -6,4 +6,6 @@ LINUX_VERSION_EXTENSION = "-acrn-kernel-uos"
 
 SUMMARY = "ACRN Kernel (UOS)"
 
-KERNEL_FEATURES:append = " uos_5.10.scc "
+KERNEL_FEATURES:append = " features/module-signing/signing.scc \
+                        uos_5.10.scc \
+                        "

--- a/recipes-kernel/linux/files/sos.cfg
+++ b/recipes-kernel/linux/files/sos.cfg
@@ -24,7 +24,6 @@ CONFIG_OPENVSWITCH=m
 
 
 # Let SOS kernel start from higher address to avoid its memory conflict with grub modules
-CONFIG_PHYSICAL_START=0x8000000
 CONFIG_IOMMU_SUPPORT=n
 CONFIG_INTEL_IOMMU=n
 

--- a/recipes-kernel/linux/files/uos_5.10.cfg
+++ b/recipes-kernel/linux/files/uos_5.10.cfg
@@ -1,0 +1,1 @@
+CONFIG_UIO=y


### PR DESCRIPTION
Made minor changes on Open PR#400[https://github.com/intel/meta-acrn/pull/400] and PR#392[https://github.com/intel/meta-acrn/pull/392]

sos.cfg: modify kernel physical start address

From ACRN release 2.5,hypervisor supports relocate kernel
to the guest free space. So specify the kernel physical
start address is not needed any more

Signed-off-by: wenlingz <wenling.zhang@intel.com>

###############################################

Add module signature support for looking glass

GPU SRIOV Looking-Glass solution need to use KVMFR driver to store
frame data into IVSHMEM device. This driver is provided by
looking-glass, not included in kernel. It needs kernel module
signature support to let kernel load this kvmfr.ko driver.

Signed-off-by: Peng Sun <peng.p.sun@intel.com>

###############################################

Add UIO driver for IVSHMEM device

GPU SRIOV Looking-Glass display virtualization solution need to
store frame data into IVSHMEM device and transfer them to SOS
for display. This is needed by IVSHMEM device in the UOS.

Signed-off-by: Peng Sun <peng.p.sun@intel.com>
Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>
