### PR TITLE
Fix acrn-libvirt failure with acrn-kernel/5.10

### DIFF
--- a/dynamic-layers/virtualization-layer/recipes-extended/libvirt/acrn-libvirt_6.1.0.bb
+++ b/dynamic-layers/virtualization-layer/recipes-extended/libvirt/acrn-libvirt_6.1.0.bb
@@ -45,7 +45,7 @@ SRC_URI = "git://github.com/projectacrn/acrn-libvirt.git;branch=${SRCBRANCH};des
 
 SRCBRANCH = "dev-acrn-v6.1.0"
 # with acrn v6.1.0
-SRCREV_libvirt = "f17e48557f8e796c6074a0d14708eaf5e9e0c3fa"
+SRCREV_libvirt = "76cc3a01580349cfb5d2eaf7159d959990070313"
 SRCREV_keycodemapdb = "27acf0ef828bf719b2053ba398b195829413dbdd"
 
 inherit autotools gettext update-rc.d pkgconfig ptest systemd useradd perlnative

--- a/recipes-kernel/linux/acrn-kernel_5.10.inc
+++ b/recipes-kernel/linux/acrn-kernel_5.10.inc
@@ -14,7 +14,7 @@ KMETA_BRANCH = "yocto-5.10"
 
 
 LINUX_VERSION = "5.10.52"
-SRCREV_machine = "a827327e71e9b9bbedaf68780c799f0a6f597c28"
+SRCREV_machine = "1c1a7f4768f97aae3917f42e9adf7afd84c1561c"
 SRCREV_meta = "eb09284047fec2f09d62068c338ae320c6681bd1"
 
 DEPENDS += "elfutils-native openssl-native util-linux-native"


### PR DESCRIPTION
acrn-kernel/5.10: include libvirt patches

This update includes:
1c1a7f4768f9 virt: acrn: add acrn hypervisor log back
a7878a2c4234 virt: acrn: update HSM ioctl about platform info getting
92d5bb205405 config: remove kernel physical start address
e381af0b6aa1 config: Enabled Intel I225 NIC PTM capability
7fa58bb554f2 config: add AST driver(ASPEED GPU)

acrn-libvirt: update to include fix platform info and offline cpu issue

https://github.com/projectacrn/acrn-libvirt/commit/76cc3a01580349cfb5d2eaf7159d959990070313

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>