### PR TITLE
acrn: update to tag v2.6

### DIFF
--- a/recipes-core/acrn/acrn-common.inc
+++ b/recipes-core/acrn/acrn-common.inc
@@ -10,7 +10,7 @@ SRC_URI = "git://github.com/projectacrn/acrn-hypervisor.git;branch=${SRCBRANCH};
 # Snapshot tags are of the format:
 # acrn-<year>w<week>.<day>-<timestamp><pass|fail>
 PV = "2.6"
-SRCREV = "9bf80f916e1bdf86417de5e395dd3a4f7f62ebe7"
+SRCREV = "f5935afc4fe4143ce5ab31ee1ab87ecb07e9ac18"
 SRCBRANCH = "release_2.6"
 
 UPSTREAM_CHECK_GITTAGREGEX = "^v(?P<pver>\d+(\.\d+)+)$"


### PR DESCRIPTION
https://github.com/projectacrn/acrn-hypervisor/releases/tag/v2.6

It also update recipe to include lastest commits:
f5935afc4 version:2.6
c3473b589 config_tools: schema: revert to old schema
e678dc8e7 doc: pick doc updates for v2.6 release
eade39758 Makefile: fix wrong reference to board XML and skip binary in diffconfig

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>