### PR TITLE
docs: update for honister release

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -8,7 +8,7 @@ BBFILE_PATTERN_meta-acrn = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-acrn = "5"
 
 LAYERDEPENDS_meta-acrn = "core intel meta-python"
-LAYERSERIES_COMPAT_meta-acrn = "dunfell gatesgarth hardknott honister"
+LAYERSERIES_COMPAT_meta-acrn = "dunfell hardknott honister"
 
 BBFILES_DYNAMIC += " \
     virtualization-layer:${LAYERDIR}/dynamic-layers/virtualization-layer/*/*/*.bb \

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -55,7 +55,7 @@ ACRN is supported on the following Intel platforms:
 * Tiger Lake
 * Elkhart Lake
 
-About minimum system requirements and limitations, please find more information at [Supported Hardware](https://projectacrn.github.io/2.4/reference/hardware.html)
+About minimum system requirements and limitations, please find more information at [Supported Hardware](https://projectacrn.github.io/2.5/reference/hardware.html)
 
 
 ## Set Up Build Host
@@ -85,13 +85,13 @@ $ sudo apt-get install gawk wget git-core diffstat unzip texinfo gcc-multilib bu
 ### Dependencies
 
 meta-acrn layer depends on:
-* [poky](https://git.yoctoproject.org/cgit/cgit.cgi/poky), branch master [or hardknott/gatesgarth/dunfell]
-* [meta-oe](https://github.com/openembedded/meta-openembedded/tree/master/meta-oe), branch master [or hardknott/gatesgarth/dunfell]
-* [meta-python](https://github.com/openembedded/meta-openembedded/tree/master/meta-python), branch master [or hardknott/gatesgarth/dunfell]
-* [meta-filesystems](https://github.com/openembedded/meta-openembedded/tree/master/meta-filesystems), branch master [or hardknott/gatesgarth/dunfell]
-* [meta-networking](https://github.com/openembedded/meta-openembedded/tree/master/meta-networking), branch master [or hardknott/gatesgarth/dunfell]
-* [meta-virtualization](https://git.yoctoproject.org/cgit/cgit.cgi/meta-virtualization), branch master [or hardknott/gatesgarth/dunfell]
-* [meta-intel](https://git.yoctoproject.org/cgit/cgit.cgi/meta-intel), branch master [or hardknott/gatesgarth/dunfell]
+* [poky](https://git.yoctoproject.org/cgit/cgit.cgi/poky), branch honister
+* [meta-oe](https://github.com/openembedded/meta-openembedded/tree/master/meta-oe), branch honister
+* [meta-python](https://github.com/openembedded/meta-openembedded/tree/master/meta-python), branch honister
+* [meta-filesystems](https://github.com/openembedded/meta-openembedded/tree/master/meta-filesystems), branch honister
+* [meta-networking](https://github.com/openembedded/meta-openembedded/tree/master/meta-networking), branch honister
+* [meta-virtualization](https://git.yoctoproject.org/cgit/cgit.cgi/meta-virtualization), branch honister
+* [meta-intel](https://git.yoctoproject.org/cgit/cgit.cgi/meta-intel), branch honister
 
 ### Build Image
 
@@ -318,8 +318,10 @@ Supported Boards:
 - nuc7i7dnb
 - whl-ipc-i5
 - whl-ipc-i7
+- nuc11tnbi5
 
-For More information, Please check [Supported Hardware](https://projectacrn.github.io/2.4/reference/hardware.html)
+
+For More information, Please check [Supported Hardware](https://projectacrn.github.io/2.5/reference/hardware.html)
 
 #### ACRN SCENARIO Configuration
 
@@ -334,9 +336,9 @@ Supported scenarios:
 - hybrid
 - hybrid_rt
 
-For more information, please check [Build With the ACRN Scenario](https://projectacrn.github.io/2.4/getting-started/building-from-source.html#build-with-the-acrn-scenario)
+For more information, please check [Build With the ACRN Scenario](https://projectacrn.github.io/2.5/getting-started/building-from-source.html#build-with-the-acrn-scenario)
 
-To customize ACRN Configruation, please check [Introduction to ACRN Configuration](https://projectacrn.github.io/2.4/tutorials/acrn_configuration_tool.html)
+To customize ACRN Configruation, please check [Introduction to ACRN Configuration](https://projectacrn.github.io/2.5/tutorials/acrn_configuration_tool.html)
 
 #### ACRN BUILD MODE Configuration
 
@@ -409,7 +411,7 @@ For example, using hybrid scenario for nuc7i7dnb:
 * ACRN_EFI_GRUB2_MOD_CFG wic variable (semicolon (;) separated list)
     to make additional entries in grub.cfg i.e insmod ext3
 
-For more information, please check [Update Ubuntu GRUB](https://projectacrn.github.io/2.4/tutorials/using_hybrid_mode_on_nuc.html#update-ubuntu-grub)
+For more information, please check [Update Ubuntu GRUB](https://projectacrn.github.io/2.5/tutorials/using_hybrid_mode_on_nuc.html#update-ubuntu-grub)
 and [acrn-bootconf.bbclass](https://github.com/intel/meta-acrn/blob/master/classes/acrn-bootconf.bbclass)
 
 
@@ -460,8 +462,6 @@ Now build the installer image:
 ```
 $ bitbake mc:installer:acrn-image-base
 ```
-
-> Currently ACRN WIC Installer is supported only OE-Core(poky) `master`, `hardknott` and `gatesgarth`. Support for `dunfell` is still in progress.
 
 ## Tested Hardware
 The following undergo regular basic testing with their respective MACHINE types.

--- a/docs/qa.md
+++ b/docs/qa.md
@@ -4,7 +4,7 @@
 
 All tests should be ran primarily on the supported platform:
 
-* Kaby Lake NUC ([details here](https://projectacrn.github.io/2.4/reference/hardware.html#verified-platforms-according-to-acrn-usage))
+* Kaby Lake NUC ([details here](https://projectacrn.github.io/2.5/reference/hardware.html#tested-platforms-by-acrn-release))
 
 ### SOS kernel without ACRN
 

--- a/docs/references.md
+++ b/docs/references.md
@@ -2,19 +2,19 @@
 
 ## ACRN Overview
 
-* [Introduction to ACRN](https://projectacrn.github.io/2.4/introduction/index.html). Good overview.
-* [Virtio Supported Devices](https://projectacrn.github.io/2.4/developer-guides/hld/hld-virtio-devices.html#supported-virtio-devices). Some of these virtio devices are *not* upstream yet, and are only in Production Kernel.
-* [Configuring ACRN's memory use](https://projectacrn.github.io/2.4/faq.html#how-do-i-configure-acrn-s-memory-use). I hope one day this isn't required. Currently we don't expose a nice way to control this in the layer (see #12).
+* [Introduction to ACRN](https://projectacrn.github.io/2.5/introduction/index.html). Good overview.
+* [Virtio Supported Devices](https://projectacrn.github.io/2.5/developer-guides/hld/hld-virtio-devices.html#supported-virtio-devices)
+* [Configuring ACRN's memory use](https://projectacrn.github.io/2.5/faq.html#how-do-i-configure-acrn-s-memory-use).
 
 ## GVT
 
-* [ACRN High-level Graphics Virtualisation Technology (GVT) Design](https://projectacrn.github.io/2.4/developer-guides/hld/hld-APL_GVT-g.html#gvt-g-high-level-design).  Useful detailed overview of the GVT-* variations.
-* [GVT Kernel Options](https://projectacrn.github.io/2.4/user-guides/kernel-parameters.html#gvt-g-acrngt-kernel-options-details)
+* [ACRN High-level Graphics Virtualisation Technology (GVT) Design](https://projectacrn.github.io/2.5/developer-guides/hld/hld-APL_GVT-g.html#gvt-g-high-level-design).  Useful detailed overview of the GVT-* variations.
+* [GVT Kernel Options](https://projectacrn.github.io/2.5/user-guides/kernel-parameters.html#gvt-g-acrngt-kernel-options-details)
 * [Mesa Environment Variables](https://www.mesa3d.org/envvars.html). Useful to get FPS or force software paths for benchmarking.
 
 ## Other
 
-* [USB passthrough](https://projectacrn.github.io/2.4/developer-guides/hld/usb-virt-hld.html#usb-host-virtualization)
+* [USB passthrough](https://projectacrn.github.io/2.5/developer-guides/hld/usb-virt-hld.html#usb-host-virtualization)
 
 ## Kernels
 

--- a/docs/slimbootloader.md
+++ b/docs/slimbootloader.md
@@ -54,7 +54,7 @@ build$ echo Zephyr_RawImage > conf/zephyr.txt
 ```
 
 ### 5. Copy Zephyr image file to the conf/zephyr.bin
-Please refer to [Using Zephyr as User OS](https://projectacrn.github.io/1.6/tutorials/using_zephyr_as_uos.html) about how to build Zephyr
+Please refer to [Using Zephyr as User OS](https://projectacrn.github.io/2.5/tutorials/using_zephyr_as_uos.html) about how to build Zephyr
 
 ### 6. Generate SBL sign key file
 ```


### PR DESCRIPTION
layer.conf: drop gatesgarth support

Building with oe-core gatesgarth is no longer supported. Remove from
LAYERSERIES_COMPAT

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>
