### PR TITLE
acrn: update build file to install serial configuration file

### DIFF
--- a/recipes-core/acrn/acrn-hypervisor.bb
+++ b/recipes-core/acrn/acrn-hypervisor.bb
@@ -71,6 +71,11 @@ do_deploy() {
 		install -m 0755 ${D}${libdir}/acrn/acpi/ACPI_*.bin ${DEPLOYDIR}
 	fi
 
+	rm -f ${DEPLOYDIR}/serial.conf
+	if [ -x ${D}${libdir}/acrn/serial.conf ]; then
+		install -m 0755 ${D}${libdir}/acrn/serial.conf ${DEPLOYDIR}
+	fi
+
 	if [ -x ${D}${libdir}/acrn/boot.efi ]; then
 		install -m 0755 ${D}${libdir}/acrn/boot.efi ${DEPLOYDIR}
 	fi


### PR DESCRIPTION
This serail configuration file is used to configure non-standard
serial ports for service VM and these serial ports are emulated
by hypervisor to do communication between service VM and user VM.

Signed-off-by: Xiangyang Wu <xiangyang.wu@intel.com>