### PR TITLE
acrn: supress openssl 3.0 deprecated-declarations warnings for now

### DIFF
--- a/recipes-core/acrn/acrn-common.inc
+++ b/recipes-core/acrn/acrn-common.inc
@@ -5,6 +5,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=b762ef53db85c389256a9d215053edf7"
 
 SRC_URI = "git://github.com/projectacrn/acrn-hypervisor.git;branch=${SRCBRANCH} \
             file://0001-crashlog-fix-build-issue-with-e2fsprogs-v1.46.2.patch \
+            file://0001-acrnprobe-supress-openssl-3.0-deprecated-declaration.patch \
 "
 
 # Snapshot tags are of the format:

--- a/recipes-core/acrn/acrn-tools.bb
+++ b/recipes-core/acrn/acrn-tools.bb
@@ -2,7 +2,7 @@ require acrn-common.inc
 
 inherit pkgconfig systemd
 
-DEPENDS += "numactl systemd e2fsprogs libevent libxml2 openssl"
+DEPENDS += "numactl systemd e2fsprogs libevent libxml2 openssl-native"
 RDEPENDS:${PN} += "bash"
 
 do_compile() {

--- a/recipes-core/acrn/files/0001-acrnprobe-supress-openssl-3.0-deprecated-declaration.patch
+++ b/recipes-core/acrn/files/0001-acrnprobe-supress-openssl-3.0-deprecated-declaration.patch
@@ -1,0 +1,78 @@
+From 2dcffb5654e7410faa59e8ca608b82932a9a9ec6 Mon Sep 17 00:00:00 2001
+From: Naveen Saini <naveen.kumar.saini@intel.com>
+Date: Tue, 2 Nov 2021 13:45:36 +0800
+Subject: [PATCH] acrnprobe: supress openssl 3.0 deprecated declaration
+ warnings
+
+With openssl 3.0, SHA256_Init, SHA256_Update, SHA256_Final,
+MD5_Init, MD5_Update, MD5_Final  APIs are deprecated,
+which causing acrnprobe & devicemodel compilation failure.
+
+Supress warnings for now until fixed in upstream
+
+Upstream-Status: Pending
+
+Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>
+---
+ devicemodel/Makefile                             | 16 +++++++++++++++-
+ .../debug_tools/acrn_crashlog/acrnprobe/Makefile | 11 +++++++++++
+ 2 files changed, 26 insertions(+), 1 deletion(-)
+
+diff --git a/devicemodel/Makefile b/devicemodel/Makefile
+index fb71657f9..f30157870 100644
+--- a/devicemodel/Makefile
++++ b/devicemodel/Makefile
+@@ -30,13 +30,27 @@ CFLAGS += -D_GNU_SOURCE
+ CFLAGS += -DNO_OPENSSL
+ CFLAGS += -m64
+ CFLAGS += -Wall -ffunction-sections
+-CFLAGS += -Werror
+ CFLAGS += -O2 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2
+ CFLAGS += -Wformat -Wformat-security -fno-strict-aliasing
+ CFLAGS += -fno-delete-null-pointer-checks -fwrapv
+ CFLAGS += -fpie
+ CFLAGS += -Wno-stringop-truncation -Wno-address-of-packed-member
+ 
++# With openssl 3.0, MD5_Init, MD5_Update, MD5_Final APIs are deprecated
++# Error:
++# | cc1: all warnings being treated as errors
++# | hw/pci/virtio/virtio_net.c: In function 'virtio_net_init':
++# | hw/pci/virtio/virtio_net.c:919:17: error: 'MD5_Init' is deprecated: Since OpenSSL 3.0 [-Werror=deprecated-declarations]
++OPENSSLBIN := $(shell which openssl)
++OPENSSLVERSIONGTEQ3 := $(shell expr `$(OPENSSLBIN) version | cut -f1 -d. | cut -f2 -d\ ` \>= 3)
++$(info $$OPENSSLVERSIONGTEQ3 is [${OPENSSLVERSIONGTEQ3}])
++ifeq "$(OPENSSLVERSIONGTEQ3)" "1"
++CFLAGS += -Wno-error
++else
++CFLAGS += -Werror
++endif
++
++
+ CFLAGS += -I$(BASEDIR)/include
+ CFLAGS += -I$(BASEDIR)/include/public
+ CFLAGS += -I$(DM_OBJDIR)/include
+diff --git a/misc/debug_tools/acrn_crashlog/acrnprobe/Makefile b/misc/debug_tools/acrn_crashlog/acrnprobe/Makefile
+index 6e1cbbc65..b3b3985ec 100644
+--- a/misc/debug_tools/acrn_crashlog/acrnprobe/Makefile
++++ b/misc/debug_tools/acrn_crashlog/acrnprobe/Makefile
+@@ -11,6 +11,17 @@ CFLAGS 		+= $(INCLUDE)
+ CFLAGS 		+= -fdata-sections
+ CFLAGS 		+= -fcommon
+ 
++# With openssl 3.0, SHA256_Init, SHA256_Update, SHA256_Final APIs are deprecated
++# Error:
++# probeutils.c:118:9: error: 'SHA256_Init' is deprecated: Since OpenSSL 3.0 [-Werror=deprecated-declarations]
++# Supress them until fixed in upstream
++OPENSSLBIN := $(shell which openssl)
++OPENSSLVERSIONGTEQ3 := $(shell expr `$(OPENSSLBIN) version | cut -f1 -d. | cut -f2 -d\ ` \>= 3)
++$(info $$OPENSSLVERSIONGTEQ3 is [${OPENSSLVERSIONGTEQ3}])
++ifeq "$(OPENSSLVERSIONGTEQ3)" "1"
++    CFLAGS += -Wno-deprecated-declarations
++endif
++
+ LDFLAGS 	+= $(LIBS) -Wl,--gc-sections
+ 
+ TARGET		= $(BUILDDIR)/acrnprobe/bin/acrnprobe
+-- 
+2.17.1
+


### PR DESCRIPTION
Fix build failure by supressing warnings until its fixed upstream.

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>