### PR TITLE
acrn-libvirt: specify branch and https protocol to avoid warnings

### DIFF
--- a/dynamic-layers/virtualization-layer/recipes-extended/libvirt/acrn-libvirt_6.1.0.bb
+++ b/dynamic-layers/virtualization-layer/recipes-extended/libvirt/acrn-libvirt_6.1.0.bb
@@ -27,8 +27,8 @@ CVE_PRODUCT = "libvirt"
 #connman blocks the 53 port and libvirtd can't start its DNS service
 RCONFLICTS:${PN}_libvirtd = "connman"
 
-SRC_URI = "git://github.com/projectacrn/acrn-libvirt.git;branch=${SRCBRANCH};destsuffix=acrn-libvirt-${PV};name=libvirt \
-           git://gitlab.com/keycodemap/keycodemapdb.git;protocol=https;destsuffix=acrn-libvirt-${PV}/src/keycodemapdb;name=keycodemapdb \
+SRC_URI = "git://github.com/projectacrn/acrn-libvirt.git;protocol=https;branch=${SRCBRANCH};destsuffix=acrn-libvirt-${PV};name=libvirt \
+           git://gitlab.com/keycodemap/keycodemapdb.git;protocol=https;branch=master;destsuffix=acrn-libvirt-${PV}/src/keycodemapdb;name=keycodemapdb \
            file://tools-add-libvirt-net-rpc-to-virt-host-validate-when.patch \
            file://libvirtd.sh \
            file://libvirtd.conf \
@@ -389,6 +389,11 @@ do_install:append() {
 
 	# virt-login-shell needs to run with setuid permission
 	chmod 4755 ${D}${bindir}/virt-login-shell
+
+	# Remove /var/log/libvirt as anything created in /var/log will not be
+	# available when tmpfs is mounted at /var/volatile/log.
+	rm -rf ${D}${localstatedir}/log
+
 }
 
 EXTRA_OECONF += " \

--- a/recipes-core/acrn/acrn-common.inc
+++ b/recipes-core/acrn/acrn-common.inc
@@ -3,7 +3,7 @@ HOMEPAGE = "https://projectacrn.org/"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b762ef53db85c389256a9d215053edf7"
 
-SRC_URI = "git://github.com/projectacrn/acrn-hypervisor.git;branch=${SRCBRANCH} \
+SRC_URI = "git://github.com/projectacrn/acrn-hypervisor.git;protocol=https;branch=${SRCBRANCH} \
             file://0001-crashlog-fix-build-issue-with-e2fsprogs-v1.46.2.patch \
             file://0001-acrnprobe-supress-openssl-3.0-deprecated-declaration.patch \
 "


### PR DESCRIPTION
Add branch name explicitly to SRC_URI where it's not defined and
switch to using https protocol for Github projects.

OE-Core now has a QA check to see if /var/log is empty. Since /var/log
is usually a symlink to /var/volatile/log, anything installed here won't actually be available.

Remove the directory.

acrn: specify https protocol to avoid warnings

Add branch name explicitly to SRC_URI where it's not defined and
switch to using https protocol for Github projects.

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>
