### PR TITLE
acrn-libvirt: update to include latest commits

### DIFF
--- a/dynamic-layers/virtualization-layer/recipes-extended/libvirt/acrn-libvirt_6.1.0.bb
+++ b/dynamic-layers/virtualization-layer/recipes-extended/libvirt/acrn-libvirt_6.1.0.bb
@@ -45,7 +45,7 @@ SRC_URI = "git://github.com/projectacrn/acrn-libvirt.git;protocol=https;branch=$
 
 SRCBRANCH = "dev-acrn-v6.1.0"
 # with acrn v6.1.0
-SRCREV_libvirt = "76cc3a01580349cfb5d2eaf7159d959990070313"
+SRCREV_libvirt = "c4315b7f6350d5184e38103fc59cdd6d408884dd"
 SRCREV_keycodemapdb = "27acf0ef828bf719b2053ba398b195829413dbdd"
 
 inherit autotools gettext update-rc.d pkgconfig ptest systemd useradd perlnative


### PR DESCRIPTION
This update includes:
acrn-driver: don't pass UUID to acrn-dm
acrn-driver: update calculation of cpu affinity and UUID
acrn-driver: enable related auto start commands
acrn-driver: add call back to check guest persistent

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>