### PR TITLE
acrn: update to daily tag acrn-2021w46.3-180000p

### DIFF
--- a/conf/distro/acrn-demo-sos.conf
+++ b/conf/distro/acrn-demo-sos.conf
@@ -17,13 +17,10 @@ PREFERRED_PROVIDER_nativesdk-libvirt = "nativesdk-acrn-libvirt"
 PREFERRED_VERSION_python3-docutils = "0.16"
 PREFERRED_VERSION_python3-docutils-native = "0.16"
 
-
-# ACRN hypervisor log setting, sensible defaults
-LINUX_ACRN_APPEND ?= "hvlog=2M@0xE00000 ${@bb.utils.contains('EFI_PROVIDER','grub-efi','memmap=2M\$0xE00000','memmap=2M$0xE00000',d)} "
 # GVT enabling. SOS has pipe 0, one UOS has the rest.
 LINUX_GVT_APPEND ?= "i915.enable_gvt=1 i915.nuclear_pageflip=1 "
 
-APPEND += "${LINUX_ACRN_APPEND} ${LINUX_GVT_APPEND}"
+APPEND += " ${LINUX_GVT_APPEND}"
 
 EFI_PROVIDER = "grub-efi"
 GRUB_BUILDIN:append = " multiboot2 "

--- a/recipes-core/acrn/acrn-common.inc
+++ b/recipes-core/acrn/acrn-common.inc
@@ -11,9 +11,9 @@ SRC_URI = "git://github.com/projectacrn/acrn-hypervisor.git;protocol=https;branc
 # Snapshot tags are of the format:
 # acrn-<year>w<week>.<day>-<timestamp><pass|fail>
 PV = "2.7"
-SRCREV = "79a5d7a787ea8923ba9859b1f1f88ad252796d49"
+SRCREV = "5a18c694197bd4314f619fa2a4cfabdd90da74e0"
 SRCREV_innersrc = "91c34ec6b3628a0e4b077adf388978e1f5d358af"
-SRCBRANCH = "master"
+SRCBRANCH = "release_2.7"
 
 UPSTREAM_CHECK_GITTAGREGEX = "^v(?P<pver>\d+(\.\d+)+)$"
 

--- a/recipes-core/acrn/acrn-hypervisor/hypervisor-dont-build-pre_build.patch
+++ b/recipes-core/acrn/acrn-hypervisor/hypervisor-dont-build-pre_build.patch
@@ -1,6 +1,6 @@
-From b4ebadc216cc81e81edfe10cd0643429aa76bbee Mon Sep 17 00:00:00 2001
+From e972f8a5dc58e42374da73a5757945a1215fed1d Mon Sep 17 00:00:00 2001
 From: Naveen Saini <naveen.kumar.saini@intel.com>
-Date: Tue, 17 Aug 2021 11:25:10 +0800
+Date: Wed, 17 Nov 2021 11:38:06 +0800
 Subject: [PATCH] Execute pre_build_check during hypervisor build is causing
  error
 
@@ -16,10 +16,10 @@ Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>
  1 file changed, 3 deletions(-)
 
 diff --git a/hypervisor/Makefile b/hypervisor/Makefile
-index 1e70bb5e0..ee1ae9920 100644
+index a455b836a..4c82704c1 100644
 --- a/hypervisor/Makefile
 +++ b/hypervisor/Makefile
-@@ -391,9 +391,6 @@ install-debug: $(HV_OBJDIR)/$(HV_FILE).map $(HV_OBJDIR)/$(HV_FILE).out
+@@ -409,9 +409,6 @@ install-debug: $(HV_OBJDIR)/$(HV_FILE).map $(HV_OBJDIR)/$(HV_FILE).out
  
  .PHONY: pre_build
  pre_build: $(HV_CONFIG_H) $(HV_CONFIG_TIMESTAMP)
@@ -28,7 +28,7 @@ index 1e70bb5e0..ee1ae9920 100644
 -	@$(HV_OBJDIR)/hv_prebuild_check.out
  	@echo "generate the binary of ACPI tables for pre-launched VMs ..."
  	python3 ../misc/config_tools/acpi_gen/bin_gen.py --board $(HV_OBJDIR)/.board.xml --scenario $(HV_OBJDIR)/.scenario.xml --asl $(HV_CONFIG_DIR) --out $(HV_OBJDIR)
- 
+ 	@echo "generate the serial configuration file for service VM ..."
 -- 
 2.17.1
 

--- a/recipes-kernel/linux/acrn-kernel_5.10.inc
+++ b/recipes-kernel/linux/acrn-kernel_5.10.inc
@@ -9,12 +9,12 @@ SRC_URI:prepend = "git://github.com/projectacrn/acrn-kernel.git;protocol=https;n
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-KBRANCH = "master"
+KBRANCH = "release_2.7"
 KMETA_BRANCH = "yocto-5.10"
 
 
-LINUX_VERSION = "5.10.52"
-SRCREV_machine = "1c1a7f4768f97aae3917f42e9adf7afd84c1561c"
+LINUX_VERSION = "5.10.65"
+SRCREV_machine = "9db1395ec52680d70c96b571abca7e0f79759e28"
 SRCREV_meta = "eb09284047fec2f09d62068c338ae320c6681bd1"
 
 DEPENDS += "elfutils-native openssl-native util-linux-native"


### PR DESCRIPTION
ACRN 2.7 RC1

Switched to release_2.7 branch.

Removed hvlog and memmap parameters from acrn commandline(Service VM bootargs)[1].

[1]
https://github.com/projectacrn/acrn-hypervisor/commit/3124097a787a949ea9d433340326f838b58cd19d
https://github.com/projectacrn/acrn-hypervisor/pull/6718
https://github.com/projectacrn/acrn-hypervisor/issues/6663

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>

###################################

acrn-kernel/5.10: update to 5.10.65

Switched to release_2.7 branch.

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>
