### PR TITLE
acrn: update to tag acrn-2021w48.4-180000p

### DIFF
--- a/recipes-core/acrn/acrn-common.inc
+++ b/recipes-core/acrn/acrn-common.inc
@@ -11,8 +11,8 @@ SRC_URI = "git://github.com/projectacrn/acrn-hypervisor.git;protocol=https;branc
 # Snapshot tags are of the format:
 # acrn-<year>w<week>.<day>-<timestamp><pass|fail>
 PV = "2.7"
-SRCREV = "5cbe49ab655da54ee9c3c3aba9a73fe67b7a6d33"
-SRCREV_innersrc = "91c34ec6b3628a0e4b077adf388978e1f5d358af"
+SRCREV = "ee2eb2e8e3fe2252e25f839fddc66e09722cdfc5"
+SRCREV_innersrc = "f79ebd22c0b7e4795900181a499618f22b6fe89e"
 SRCBRANCH = "release_2.7"
 
 UPSTREAM_CHECK_GITTAGREGEX = "^v(?P<pver>\d+(\.\d+)+)$"

--- a/recipes-guests/yocto/core-image-base-package/launch-base.sh
+++ b/recipes-guests/yocto/core-image-base-package/launch-base.sh
@@ -28,6 +28,7 @@ acrn-dm -A -m $mem_size -s 0:0,hostbridge \
   -s 4,virtio-net,tap0 \
   -s 7,virtio-rnd \
   --ovmf /usr/share/acrn/bios/OVMF.fd \
+  --cpu_affinity 0,1 \
   $logger_setting \
   --mac_seed $mac_seed \
   $vm_name

--- a/recipes-guests/yocto/core-image-sato-package/launch-sato.sh
+++ b/recipes-guests/yocto/core-image-sato-package/launch-sato.sh
@@ -34,6 +34,7 @@ acrn-dm -A -m $mem_size  -s 0:0,hostbridge \
   -s 4,virtio-net,tap0 \
   -s 7,virtio-rnd \
   --ovmf /usr/share/acrn/bios/OVMF.fd \
+  --cpu_affinity 0,1 \
   $logger_setting \
   --mac_seed $mac_seed \
   $vm_name

--- a/recipes-guests/yocto/core-image-weston-package/launch-weston.sh
+++ b/recipes-guests/yocto/core-image-weston-package/launch-weston.sh
@@ -34,6 +34,7 @@ acrn-dm -A -m $mem_size -s 0:0,hostbridge \
   -s 4,virtio-net,tap0 \
   -s 7,virtio-rnd \
   --ovmf /usr/share/acrn/bios/OVMF.fd \
+  --cpu_affinity 0,1 \
   $logger_setting \
   --mac_seed $mac_seed \
   $vm_name


### PR DESCRIPTION
ACRN 2.7 RC3

##################################################

launch-script: add --cpu_affinity acrn-dm parameter

Assign physical CPUs (pCPUs) to post-lauched VM.

Note: Guest VM launch script should be generated using config-tools

This layer carryies sample lauch scripts with works with default nuc11tnbi5 board and shared scenario.

Ref:
https://github.com/projectacrn/acrn-hypervisor/blob/release_2.7/misc/config_tools/data/nuc11tnbi5/shared.xml#L119
https://projectacrn.github.io/latest/user-guides/acrn-dm-parameters.html?highlight=cpu_affinity

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>
