### PR TITLE
acrn-hypervisor: fix lnr command not found issue

### DIFF
--- a/recipes-core/acrn/acrn-hypervisor.bb
+++ b/recipes-core/acrn/acrn-hypervisor.bb
@@ -60,11 +60,11 @@ addtask deploy after do_install before do_build
 do_deploy() {
 	install -m 0755 ${D}${libdir}/acrn/acrn.${ACRN_BOARD}.${ACRN_SCENARIO}.32.out ${DEPLOYDIR}
 	rm -f ${DEPLOYDIR}/acrn.32.out
-	lnr ${DEPLOYDIR}/acrn.${ACRN_BOARD}.${ACRN_SCENARIO}.32.out ${DEPLOYDIR}/acrn.32.out
+	ln -rs ${DEPLOYDIR}/acrn.${ACRN_BOARD}.${ACRN_SCENARIO}.32.out ${DEPLOYDIR}/acrn.32.out
 
 	install -m 0755 ${D}${libdir}/acrn/acrn.${ACRN_BOARD}.${ACRN_SCENARIO}.bin ${DEPLOYDIR}
 	rm -f ${DEPLOYDIR}/acrn.bin
-	lnr ${DEPLOYDIR}/acrn.${ACRN_BOARD}.${ACRN_SCENARIO}.bin ${DEPLOYDIR}/acrn.bin
+	ln -rs ${DEPLOYDIR}/acrn.${ACRN_BOARD}.${ACRN_SCENARIO}.bin ${DEPLOYDIR}/acrn.bin
 
 	rm -f ${DEPLOYDIR}/ACPI_*.bin
 	if [ -x ${D}${libdir}/acrn/acpi ]; then

--- a/recipes-core/acrn/acrn-hypervisor.bb
+++ b/recipes-core/acrn/acrn-hypervisor.bb
@@ -8,7 +8,7 @@ EXTRA_OEMAKE += "HV_OBJDIR=${B}/hypervisor "
 EXTRA_OEMAKE += "BOARD=${ACRN_BOARD} SCENARIO=${ACRN_SCENARIO}"
 EXTRA_OEMAKE += "EFI_OBJDIR=${B}/misc/efi-stub"
 
-SRC_URI:append:class-target += "file://hypervisor-dont-build-pre_build.patch"
+SRC_URI:append:class-target = " file://hypervisor-dont-build-pre_build.patch"
 
 inherit python3native deploy
 


### PR DESCRIPTION
scripts/lnr has been removed. So use `ln --relative --symlink` from coreutils
to create relative symlinks, instead.

#######################################################

acrn-hypervisor: fix syntax warning

Remove unnecessary "+="

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>
