### PR TITLE
acrn: update to tag acrn-2021w49.4-180000p

### DIFF
--- a/recipes-core/acrn/acrn-common.inc
+++ b/recipes-core/acrn/acrn-common.inc
@@ -10,7 +10,7 @@ SRC_URI = "git://github.com/projectacrn/acrn-hypervisor.git;protocol=https;branc
 # Snapshot tags are of the format:
 # acrn-<year>w<week>.<day>-<timestamp><pass|fail>
 PV = "2.7"
-SRCREV = "fc7e26dde8c9cca5ca645dad95b6deadde0110d2"
+SRCREV = "395174f9db66bd78b0e53f24905c2de2461e358d"
 SRCREV_innersrc = "f79ebd22c0b7e4795900181a499618f22b6fe89e"
 SRCBRANCH = "release_2.7"
 

--- a/recipes-core/acrn/acrn-hypervisor.bb
+++ b/recipes-core/acrn/acrn-hypervisor.bb
@@ -60,11 +60,11 @@ addtask deploy after do_install before do_build
 do_deploy() {
 	install -m 0755 ${D}${libdir}/acrn/acrn.${ACRN_BOARD}.${ACRN_SCENARIO}.32.out ${DEPLOYDIR}
 	rm -f ${DEPLOYDIR}/acrn.32.out
-	lnr ${DEPLOYDIR}/acrn.${ACRN_BOARD}.${ACRN_SCENARIO}.32.out ${DEPLOYDIR}/acrn.32.out
+	ln -rs ${DEPLOYDIR}/acrn.${ACRN_BOARD}.${ACRN_SCENARIO}.32.out ${DEPLOYDIR}/acrn.32.out
 
 	install -m 0755 ${D}${libdir}/acrn/acrn.${ACRN_BOARD}.${ACRN_SCENARIO}.bin ${DEPLOYDIR}
 	rm -f ${DEPLOYDIR}/acrn.bin
-	lnr ${DEPLOYDIR}/acrn.${ACRN_BOARD}.${ACRN_SCENARIO}.bin ${DEPLOYDIR}/acrn.bin
+	ln -rs ${DEPLOYDIR}/acrn.${ACRN_BOARD}.${ACRN_SCENARIO}.bin ${DEPLOYDIR}/acrn.bin
 
 	rm -f ${DEPLOYDIR}/ACPI_*.bin
 	if [ -x ${D}${libdir}/acrn/acpi ]; then


### PR DESCRIPTION
ACRN 2.7 RC5

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>

#######################################

acrn-hypervisor: fix lnr command not found issue

scripts/lnr has been removed. So use `ln --relative --symlink` from coreutils
to create relative symlinks, instead.

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>
