### PR TITLE
acrn-hypervisor: passlist CVE-2021-36145

### DIFF
--- a/recipes-core/acrn/acrn-common.inc
+++ b/recipes-core/acrn/acrn-common.inc
@@ -44,4 +44,4 @@ do_compile[dirs] = "${S}"
 do_install[dirs] = "${S}"
 
 # Fixed in v1.2 and onward
-CVE_CHECK_WHITELIST += "CVE-2019-18844"
+CVE_CHECK_WHITELIST += "CVE-2019-18844 CVE-2021-36145"


### PR DESCRIPTION
Fix is already available in ACRN v2.5.1
https://github.com/projectacrn/acrn-hypervisor/commit/f4b93f31b7e108d51bc1156ee4feacbc94a602f1

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>