### PR TITLE
linux-intel-acrn-sos/5.10: add recipe

### DIFF
--- a/recipes-kernel/linux/linux-intel-acrn-sos_5.10.bb
+++ b/recipes-kernel/linux/linux-intel-acrn-sos_5.10.bb
@@ -1,0 +1,17 @@
+require linux-intel-acrn_5.10.inc
+
+SRC_URI:append = " file://sos_5.10.scc"
+
+LINUX_VERSION_EXTENSION = "-linux-intel-acrn-sos"
+
+SUMMARY = "Linux Kernel with ACRN enabled (SOS)"
+
+KERNEL_FEATURES:append = " features/criu/criu-enable.scc \
+                          cgl/cfg/iscsi.scc \
+                          sos_5.10.scc \
+"
+
+# config warning:  'CONFIG_IRQ_REMAP' last val (y) and .config val (n) do not matchs
+# It is because, CONFIG_IRQ_REMAP depends upon IOMMU_SUPPORT, which we are explicitly disabling by setting to 'n'
+# So, to suppress this warning, set
+KCONF_AUDIT_LEVEL = "0"

--- a/recipes-kernel/linux/linux-intel-acrn-uos_5.10.bb
+++ b/recipes-kernel/linux/linux-intel-acrn-uos_5.10.bb
@@ -1,0 +1,7 @@
+require linux-intel-acrn_5.10.inc
+
+SRC_URI:append = "  file://uos_5.10.scc"
+
+LINUX_VERSION_EXTENSION = "-linux-intel-acrn-uos"
+
+SUMMARY = "Linux Kernel with ACRN enabled (UOS)"

--- a/recipes-kernel/linux/linux-intel-acrn_5.10.inc
+++ b/recipes-kernel/linux/linux-intel-acrn_5.10.inc
@@ -1,0 +1,28 @@
+SUMMARY = "Linux Kernel 5.10 with ACRN enabled"
+
+require recipes-kernel/linux/linux-intel.inc
+
+SRC_URI:append = "  file://0001-menuconfig-mconf-cfg-Allow-specification-of-ncurses-.patch"
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
+
+KBRANCH = "5.10/yocto"
+KMETA_BRANCH = "yocto-5.10"
+
+LINUX_VERSION ?= "5.10.78"
+SRCREV_machine ?= "4e8162d8163c74e46a9f0bafb860f42249702791"
+SRCREV_meta ?= "64fb693a6c11f21bab3ff9bb8dcb65a70abe05e3"
+
+DEPENDS += "elfutils-native openssl-native util-linux-native"
+
+KERNEL_FEATURES:append = " features/netfilter/netfilter.scc \
+                          features/security/security.scc  \
+                          cfg/hv-guest.scc \
+                          cfg/paravirt_kvm.scc \
+                          features/net/stmicro/stmmac.cfg \
+"
+# Following commit is backported from mainline 5.12-rc to linux-intel 5.10 kernel
+# Commit: https://github.com/torvalds/linux/commit/26499e0518a77de29e7db2c53fb0d0e9e15be8fb
+# In which 'CONFIG_DRM_GMA3600' config option is dropped.
+# This causes warning during config audit. So suppress the harmless warning for now.
+KCONF_BSP_AUDIT_LEVEL = "0"

--- a/recipes-kernel/linux/linux-intel-rt-acrn-uos_5.10.bb
+++ b/recipes-kernel/linux/linux-intel-rt-acrn-uos_5.10.bb
@@ -1,0 +1,41 @@
+SUMMARY = "Linux Preempt RT Kernel with ACRN enabled (UOS)"
+
+require recipes-kernel/linux/linux-intel.inc
+
+# PREFERRED_PROVIDER for virtual/kernel. This avoids errors when trying
+# to build multiple virtual/kernel providers.
+python () {
+    if d.getVar("KERNEL_PACKAGE_NAME", True) == "kernel" and d.getVar("PREFERRED_PROVIDER_virtual/kernel") != "linux-intel-rt-acrn-uos":
+        raise bb.parse.SkipPackage("Set PREFERRED_PROVIDER_virtual/kernel to linux-intel-rt-acrn-uos to enable it")
+}
+
+SRC_URI:append = "  file://0001-menuconfig-mconf-cfg-Allow-specification-of-ncurses-.patch \
+                    file://uos_rt_5.10.scc \
+"
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
+
+KBRANCH = "5.10/preempt-rt"
+KMETA_BRANCH = "yocto-5.10"
+
+DEPENDS += "elfutils-native openssl-native util-linux-native"
+
+LINUX_VERSION ?= "5.10.78"
+SRCREV_machine ?= "e26ab22c63212fce82e8cfaa481936c1afdb0f31"
+SRCREV_meta ?= "64fb693a6c11f21bab3ff9bb8dcb65a70abe05e3"
+
+LINUX_VERSION_EXTENSION = "-linux-intel-preempt-rt-acrn-uos"
+
+LINUX_KERNEL_TYPE = "preempt-rt"
+
+KERNEL_FEATURES:append = " features/netfilter/netfilter.scc \
+                          features/security/security.scc  \
+                          cfg/hv-guest.scc \
+                          cfg/paravirt_kvm.scc \
+                          features/net/stmicro/stmmac.cfg \
+"
+# Following commit is backported from mainline 5.12-rc to linux-intel 5.10 kernel
+# Commit: https://github.com/torvalds/linux/commit/26499e0518a77de29e7db2c53fb0d0e9e15be8fb
+# In which 'CONFIG_DRM_GMA3600' config option is dropped.
+# This causes warning during config audit. So suppress the harmless warning for now.
+KCONF_BSP_AUDIT_LEVEL = "0"


### PR DESCRIPTION
linux-intel-acrn-sos/5.10: add recipe

Add recipe to build LTS 5.10 Kernel for Service VM.

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>
######################################################
linux-intel-acrn-uos/5.10: add recipe

Add recipe to build LTS 5.10 kernel for Guest VM.

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>
######################################################
linux-intel-rt-acrn-uos/5.10: add recipe

Add recipe to build 5.10 RT kernel for Guest VM.

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>

