### PR TITLE
distro: set 5.10 kernel as default

### DIFF
--- a/conf/distro/acrn-demo-sos.conf
+++ b/conf/distro/acrn-demo-sos.conf
@@ -5,7 +5,7 @@ DISTRO_NAME += "(SOS)"
 DISTRO_FEATURES += "SOS"
 
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-intel-acrn-sos"
-PREFERRED_VERSION_linux-intel-acrn-sos ?= "5.4%"
+PREFERRED_VERSION_linux-intel-acrn-sos ?= "5.10%"
 
 PREFERRED_PROVIDER_libvirt = "acrn-libvirt"
 PREFERRED_PROVIDER_libvirt-native = "acrn-libvirt-native"

--- a/conf/distro/acrn-demo-uos.conf
+++ b/conf/distro/acrn-demo-uos.conf
@@ -4,8 +4,8 @@ DISTRO .= "-uos"
 DISTRO_NAME += "(UOS)"
 
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-intel-acrn-uos"
-PREFERRED_VERSION_linux-intel-acrn-uos ?= "5.4%"
-PREFERRED_VERSION_linux-intel-rt-acrn-uos ?= "5.4%"
+PREFERRED_VERSION_linux-intel-acrn-uos ?= "5.10%"
+PREFERRED_VERSION_linux-intel-rt-acrn-uos ?= "5.10%"
 
 # UOS images are always ext4
 IMAGE_FSTYPES = "wic ext4"


### PR DESCRIPTION
Kernel 5.4 support has been dropped.

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>