### PR TITLE
linux-intel-acrn/5.10: update to 5.10.90

### DIFF
--- a/recipes-kernel/linux/linux-intel-acrn_5.10.inc
+++ b/recipes-kernel/linux/linux-intel-acrn_5.10.inc
@@ -9,9 +9,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 KBRANCH = "5.10/yocto"
 KMETA_BRANCH = "yocto-5.10"
 
-LINUX_VERSION ?= "5.10.78"
-SRCREV_machine ?= "4e8162d8163c74e46a9f0bafb860f42249702791"
-SRCREV_meta ?= "64fb693a6c11f21bab3ff9bb8dcb65a70abe05e3"
+LINUX_VERSION ?= "5.10.90"
+SRCREV_machine ?= "92a130c4f25aedb3994ab18e243b82623c83e280"
+SRCREV_meta ?= "ad119826536616f28e4309e825b61e16357f4c7e"
 
 DEPENDS += "elfutils-native openssl-native util-linux-native"
 

--- a/recipes-kernel/linux/linux-intel-rt-acrn-uos_5.10.bb
+++ b/recipes-kernel/linux/linux-intel-rt-acrn-uos_5.10.bb
@@ -20,9 +20,9 @@ KMETA_BRANCH = "yocto-5.10"
 
 DEPENDS += "elfutils-native openssl-native util-linux-native"
 
-LINUX_VERSION ?= "5.10.78"
-SRCREV_machine ?= "e26ab22c63212fce82e8cfaa481936c1afdb0f31"
-SRCREV_meta ?= "64fb693a6c11f21bab3ff9bb8dcb65a70abe05e3"
+LINUX_VERSION ?= "5.10.90"
+SRCREV_machine ?= "7cc354621926dbf3eaf754661fe39f9554018905"
+SRCREV_meta ?= "ad119826536616f28e4309e825b61e16357f4c7e"
 
 LINUX_VERSION_EXTENSION = "-linux-intel-preempt-rt-acrn-uos"
 


### PR DESCRIPTION

Updated kernel config too.

v5.10.90: (228 commits)
Revert "drm/ast: potential dereference of null pointer"
Revert "drm/amd/pm: fix a potential gpu_metrics_table memory leak"
Revert "drm/amdgpu: correct register access for RLC_JUMP_TABLE_RESTORE"
Revert "drm/amdgpu: When the VCN(1.0) block is suspended, powergating is explicitly enabled"
Revert "drm/amdgpu: add support for IP discovery gc_info table v2"
Linux 5.10.90
bpf: Add kconfig knob for disabling unpriv bpf by default
perf script: Fix CPU filtering of a script's switch events
net: fix use-after-free in tw_timer_handler
Input: spaceball - fix parsing of movement data packets
Input: appletouch - initialize work before device registration
scsi: vmw_pvscsi: Set residual data length conditionally
binder: fix async_free_space accounting for empty parcels
usb: mtu3: set interval of FS intr and isoc endpoint
usb: mtu3: fix list_head check warning
usb: mtu3: add memory barrier before set GPD's HWO
usb: gadget: f_fs: Clear ffs_eventfd in ffs_data_clear.
xhci: Fresco FL1100 controller should not have BROKEN_MSI quirk set.
drm/amdgpu: add support for IP discovery gc_info table v2
drm/amdgpu: When the VCN(1.0) block is suspended, powergating is explicitly enabled
...

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>

#####################################################################

    linux-intel-rt-acrn-uos/5.10: update to v5.10.90

    updates -rt patchset to -rt60.

    Updated kernel config too.

    Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>




