### PR TITLE
acrn-libvirt: fix compile error

### DIFF
--- a/dynamic-layers/virtualization-layer/recipes-extended/libvirt/acrn-libvirt/Fix-template-matching-in-page.xsl.patch
+++ b/dynamic-layers/virtualization-layer/recipes-extended/libvirt/acrn-libvirt/Fix-template-matching-in-page.xsl.patch
@@ -1,0 +1,60 @@
+From 54814c87f3706cc8eb894634ebef0f9cf7dabae6 Mon Sep 17 00:00:00 2001
+From: Martin Kletzander <mkletzan@redhat.com>
+Date: Mon, 21 Feb 2022 09:26:13 +0100
+Subject: [PATCH] docs: Fix template matching in page.xsl
+
+Our last default template had a match of "node()" which incidentally matched
+everything, including text nodes.  Since this has the same priority according to
+the XSLT spec, section 5.5:
+
+  https://www.w3.org/TR/1999/REC-xslt-19991116#conflict
+
+this is an error.  Also according to the same spec section, the XSLT processor
+may signal the error or pick the last rule.
+
+This was uncovered with libxslt 1.1.35 which contains the following commit:
+
+  https://gitlab.gnome.org/GNOME/libxslt/-/commit/b0074eeca3c6b21b4da14fdf712b853900c51635
+
+which makes the build fail with:
+
+  runtime error: file ../docs/page.xsl line 223 element element
+  xsl:element: The effective name '' is not a valid QName.
+
+because our last rule also matches text nodes and we are trying to extract the
+node name out of them.
+
+To fix this we change the match to "*" which only matches elements and not all
+the nodes, and to avoid any possible errors with different XSLT processors we
+also bump the priority of the match="text()" rule a little higher, just in case
+someone needs to use an XSLT processor that chooses signalling the error instead
+of the optional recovery.
+
+https://bugs.gentoo.org/833586
+
+Signed-off-by: Martin Kletzander <mkletzan@redhat.com>
+
+Upstream-Status: Backport [https://github.com/libvirt/libvirt/commit/54814c87f3706cc8eb894634ebef0f9cf7dabae6]
+Signed-off-by: Chee Yang Lee <chee.yang.lee@intel.com>
+---
+ docs/page.xsl | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/docs/page.xsl b/docs/page.xsl
+index fd67918d3b0..72a6fa08423 100644
+--- a/docs/page.xsl
++++ b/docs/page.xsl
+@@ -215,11 +215,11 @@
+     </xsl:element>
+   </xsl:template>
+ 
+-  <xsl:template match="text()" mode="copy">
++  <xsl:template match="text()" mode="copy" priority="0">
+     <xsl:value-of select="."/>
+   </xsl:template>
+ 
+-  <xsl:template match="node()" mode="copy">
++  <xsl:template match="*" mode="copy">
+     <xsl:element name="{name()}">
+       <xsl:copy-of select="./@*"/>
+       <xsl:apply-templates mode="copy" />

--- a/dynamic-layers/virtualization-layer/recipes-extended/libvirt/acrn-libvirt_6.1.0.bb
+++ b/dynamic-layers/virtualization-layer/recipes-extended/libvirt/acrn-libvirt_6.1.0.bb
@@ -41,6 +41,7 @@ SRC_URI = "git://github.com/projectacrn/acrn-libvirt.git;protocol=https;branch=$
            file://configure.ac-search-for-rpc-rpc.h-in-the-sysroot.patch \
            file://0001-build-drop-unnecessary-libgnu.la-reference.patch \
            file://gnutls-helper.py \
+           file://Fix-template-matching-in-page.xsl.patch \
           "
 
 SRCBRANCH = "dev-acrn-v6.1.0"


### PR DESCRIPTION
Backport patch from Libvirt to fix compile error 

Signed-off-by: Chee Yang Lee <chee.yang.lee@intel.com>