### PR TITLE
Master next update

### DIFF
--- a/recipes-kernel/linux/linux-intel-acrn_5.10.inc
+++ b/recipes-kernel/linux/linux-intel-acrn_5.10.inc
@@ -9,9 +9,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 KBRANCH = "5.10/yocto"
 KMETA_BRANCH = "yocto-5.10"
 
-LINUX_VERSION ?= "5.10.90"
-SRCREV_machine ?= "92a130c4f25aedb3994ab18e243b82623c83e280"
-SRCREV_meta ?= "ad119826536616f28e4309e825b61e16357f4c7e"
+LINUX_VERSION ?= "5.10.100"
+SRCREV_machine ?= "27af876b14236b85fce1b2e38fb72ae4ce18550a"
+SRCREV_meta ?= "792f1272dd0d68d5dba0ff35949b2094f818227e"
 
 DEPENDS += "elfutils-native openssl-native util-linux-native"
 

--- a/recipes-kernel/linux/linux-intel-rt-acrn-uos_5.10.bb
+++ b/recipes-kernel/linux/linux-intel-rt-acrn-uos_5.10.bb
@@ -20,9 +20,9 @@ KMETA_BRANCH = "yocto-5.10"
 
 DEPENDS += "elfutils-native openssl-native util-linux-native"
 
-LINUX_VERSION ?= "5.10.90"
-SRCREV_machine ?= "7cc354621926dbf3eaf754661fe39f9554018905"
-SRCREV_meta ?= "ad119826536616f28e4309e825b61e16357f4c7e"
+LINUX_VERSION ?= "5.10.100"
+SRCREV_machine ?= "14aee1cf07a1697b08fde5ec258e7bc1f062705c"
+SRCREV_meta ?= "792f1272dd0d68d5dba0ff35949b2094f818227e"
 
 LINUX_VERSION_EXTENSION = "-linux-intel-preempt-rt-acrn-uos"
 

--- a/recipes-kernel/linux/linux-intel-rt-acrn-uos_5.4.bb
+++ b/recipes-kernel/linux/linux-intel-rt-acrn-uos_5.4.bb
@@ -20,9 +20,9 @@ KMETA_BRANCH = "yocto-5.4"
 
 DEPENDS += "elfutils-native openssl-native util-linux-native"
 
-LINUX_VERSION ?= "5.4.123"
-SRCREV_machine ?= "31aebc6b6377591f43c127ccd9230ea01afb0a76"
-SRCREV_meta ?= "76aa6f85d62f7fc05c4b3e371fafe74290fc2238"
+LINUX_VERSION ?= "5.4.177"
+SRCREV_machine ?= "7234dd7d1a1b3d6e3dee299383f25adfd542db33"
+SRCREV_meta ?= "337c38059f2fd562199b0e5133b71410240004e9"
 
 LINUX_VERSION_EXTENSION = "-linux-intel-preempt-rt-acrn-uos"
 


### PR DESCRIPTION
linux-intel-acrn: update to 5.10.100

update to lts-v5.10.100-yocto-220223T232711Z.
also update kernel cache.

Signed-off-by: Chee Yang Lee <chee.yang.lee@intel.com>
Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>
#####################################################

linux-intel-rt-acrn-uos : update to 5.10.100-rt62

update to lts-v5.10.100-rt62-preempt-rt-220226T032749Z.

also update kmeta.

Signed-off-by: Chee Yang Lee <chee.yang.lee@intel.com>
Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>

######################################################

linux-intel-rt-acrn-uos: update to 5.4.177

update to lts-v5.4.177-rt69-preempt-rt-220210T012802Z.

also update kmeta.

Signed-off-by: Chee Yang Lee <chee.yang.lee@intel.com>
Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>


