### PR TITLE
Master next update

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -8,7 +8,7 @@ BBFILE_PATTERN_meta-acrn = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-acrn = "5"
 
 LAYERDEPENDS_meta-acrn = "core intel meta-python"
-LAYERSERIES_COMPAT_meta-acrn = "dunfell gatesgarth hardknott honister kirkstone"
+LAYERSERIES_COMPAT_meta-acrn = "kirkstone"
 
 BBFILES_DYNAMIC += " \
     virtualization-layer:${LAYERDIR}/dynamic-layers/virtualization-layer/*/*/*.bb \

--- a/recipes-core/acrn/acrn-common.inc
+++ b/recipes-core/acrn/acrn-common.inc
@@ -10,7 +10,7 @@ SRC_URI = "git://github.com/projectacrn/acrn-hypervisor.git;protocol=https;branc
 # Snapshot tags are of the format:
 # acrn-<year>w<week>.<day>-<timestamp><pass|fail>
 PV = "3.0"
-SRCREV = "3d8fa8094941077f8ee15a3def0f5e79a201a173"
+SRCREV = "696ba31be804d5334afbd695189ae13f351ff652"
 SRCREV_innersrc = "eae56846fc13b1908082bd0bf19104a240d1b7a7"
 SRCBRANCH = "master"
 

--- a/recipes-kernel/linux/linux-intel-acrn_5.10.inc
+++ b/recipes-kernel/linux/linux-intel-acrn_5.10.inc
@@ -9,9 +9,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 KBRANCH = "5.10/yocto"
 KMETA_BRANCH = "yocto-5.10"
 
-LINUX_VERSION ?= "5.10.100"
-SRCREV_machine ?= "27af876b14236b85fce1b2e38fb72ae4ce18550a"
-SRCREV_meta ?= "792f1272dd0d68d5dba0ff35949b2094f818227e"
+LINUX_VERSION ?= "5.10.109"
+SRCREV_machine ?= "6410aba3b60feba47b9713f297d9b3bdb79981f5"
+SRCREV_meta ?= "19e7547dd6617760d6094b7a42da1a718b5a96ee"
 
 DEPENDS += "elfutils-native openssl-native util-linux-native"
 

--- a/recipes-kernel/linux/linux-intel-rt-acrn-uos_5.10.bb
+++ b/recipes-kernel/linux/linux-intel-rt-acrn-uos_5.10.bb
@@ -20,9 +20,9 @@ KMETA_BRANCH = "yocto-5.10"
 
 DEPENDS += "elfutils-native openssl-native util-linux-native"
 
-LINUX_VERSION ?= "5.10.100"
-SRCREV_machine ?= "14aee1cf07a1697b08fde5ec258e7bc1f062705c"
-SRCREV_meta ?= "792f1272dd0d68d5dba0ff35949b2094f818227e"
+LINUX_VERSION ?= "5.10.109"
+SRCREV_machine ?= "1a9009a376865b4c0d381b8cd683ca9a10b5a09a"
+SRCREV_meta ?= "19e7547dd6617760d6094b7a42da1a718b5a96ee"
 
 LINUX_VERSION_EXTENSION = "-linux-intel-preempt-rt-acrn-uos"
 


### PR DESCRIPTION
a9512bb linux-intel-rt-acrn-uos : update to 5.10.109-rt65
d999b04 linux-intel-acrn/5.10: update to v5.10.109
67436c6 layer.conf: drop support for old releases
354ac6b acrn: update to tag acrn-2022w18.1-180000p
