### PR TITLE
acrn-life-mngr: fix build failure due to gcc-12

### DIFF
--- a/recipes-core/acrn/acrn-common.inc
+++ b/recipes-core/acrn/acrn-common.inc
@@ -5,6 +5,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=b762ef53db85c389256a9d215053edf7"
 
 SRC_URI = "git://github.com/projectacrn/acrn-hypervisor.git;protocol=https;branch=${SRCBRANCH}; \
             file://0001-hv-crypto-fix-a-minor-build-Werror.patch \
+            file://0001-misc-acrnd-fix-a-minor-build-Werror.patch \
             file://0001-Makefile-disable-Werror-option-for-now.patch \
 "
 

--- a/recipes-core/acrn/files/0001-Makefile-disable-Werror-option-for-now.patch
+++ b/recipes-core/acrn/files/0001-Makefile-disable-Werror-option-for-now.patch
@@ -1,4 +1,4 @@
-From cadeb5c7b640b9b6099d6cc4e3ef1bc5d3f25887 Mon Sep 17 00:00:00 2001
+From 448c4157df53fbfa0d5731afaf8ab6f60e036be8 Mon Sep 17 00:00:00 2001
 From: Naveen Saini <naveen.kumar.saini@intel.com>
 Date: Fri, 13 May 2022 22:47:08 +0800
 Subject: [PATCH] Makefile: disable -Werror option for now
@@ -15,7 +15,7 @@ Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>
 ---
  devicemodel/Makefile                    | 2 +-
  misc/debug_tools/acrn_crashlog/Makefile | 2 +-
- misc/services/acrn_manager/Makefile     | 2 +-
+ misc/services/life_mngr/Makefile        | 2 +-
  3 files changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/devicemodel/Makefile b/devicemodel/Makefile
@@ -44,19 +44,19 @@ index c2367704e..742bef703 100644
  CFLAGS += -O2 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2
  CFLAGS += -Wformat -Wformat-security -fno-strict-aliasing
  CFLAGS += -fpie
-diff --git a/misc/services/acrn_manager/Makefile b/misc/services/acrn_manager/Makefile
-index af63b81d1..05d52905e 100644
---- a/misc/services/acrn_manager/Makefile
-+++ b/misc/services/acrn_manager/Makefile
-@@ -22,7 +22,7 @@ MANAGER_CFLAGS += -D_GNU_SOURCE
- MANAGER_CFLAGS += -DNO_OPENSSL
- MANAGER_CFLAGS += -m64
- MANAGER_CFLAGS += -Wall -ffunction-sections
--MANAGER_CFLAGS += -Werror
-+#MANAGER_CFLAGS += -Werror
- MANAGER_CFLAGS += -O2 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2
- MANAGER_CFLAGS += -Wformat -Wformat-security -fno-strict-aliasing
- MANAGER_CFLAGS += -fno-delete-null-pointer-checks -fwrapv
+diff --git a/misc/services/life_mngr/Makefile b/misc/services/life_mngr/Makefile
+index a27252c7b..80c301e8f 100644
+--- a/misc/services/life_mngr/Makefile
++++ b/misc/services/life_mngr/Makefile
+@@ -8,7 +8,7 @@ LIFEMNGR_CFLAGS += -D_GNU_SOURCE
+ LIFEMNGR_CFLAGS += -DNO_OPENSSL
+ LIFEMNGR_CFLAGS += -m64
+ LIFEMNGR_CFLAGS += -Wall -ffunction-sections
+-LIFEMNGR_CFLAGS += -Werror
++#LIFEMNGR_CFLAGS += -Werror
+ LIFEMNGR_CFLAGS += -O2 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2
+ LIFEMNGR_CFLAGS += -Wformat -Wformat-security -fno-strict-aliasing
+ LIFEMNGR_CFLAGS += -fno-delete-null-pointer-checks -fwrapv
 -- 
 2.25.1
 

--- a/recipes-core/acrn/files/0001-misc-acrnd-fix-a-minor-build-Werror.patch
+++ b/recipes-core/acrn/files/0001-misc-acrnd-fix-a-minor-build-Werror.patch
@@ -1,0 +1,32 @@
+From d625ce06773bf0f0f0c94c7f2457d743b0de9a54 Mon Sep 17 00:00:00 2001
+From: Fei Li <fei1.li@intel.com>
+Date: Fri, 13 May 2022 10:05:51 +0800
+Subject: [PATCH] misc: acrnd: fix a minor build Werror
+
+The comparison ((argv + 1)) will always evaluate as 'true' for the pointer
+operand in 'argv + 8' must not be NULL.
+
+Tracked-On: #7453
+Upstream-Status: Backported [https://github.com/projectacrn/acrn-hypervisor/commit/d625ce06773bf0f0f0c94c7f2457d743b0de9a54]
+Signed-off-by: Fei Li <fei1.li@intel.com>
+Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>
+---
+ misc/services/acrn_manager/acrnctl.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/misc/services/acrn_manager/acrnctl.c b/misc/services/acrn_manager/acrnctl.c
+index 4a60442fe..2517c8d3f 100644
+--- a/misc/services/acrn_manager/acrnctl.c
++++ b/misc/services/acrn_manager/acrnctl.c
+@@ -657,7 +657,7 @@ static int valid_start_args(struct acrnctl_cmd *cmd, int argc, char *argv[])
+ {
+ 	char df_opt[16] = "VM_NAME";
+ 
+-	if (argc != 2 || ((argv + 1) && !strcmp(argv[1], "help"))) {
++	if (argc != 2 || !strcmp(argv[1], "help")) {
+ 		printf("acrnctl %s %s\n", cmd->cmd, df_opt);
+ 		return -1;
+ 	}
+-- 
+2.25.1
+


### PR DESCRIPTION
GCC12 causing multiple warnings which are currently being treated as error.

Ignore for now, untill not fixed upstream.

Open Issue: https://github.com/projectacrn/acrn-hypervisor/issues/7453

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>