### PR TITLE
acrn: update to acrn-2022w21.5-180000p

### DIFF
--- a/recipes-core/acrn/acrn-common.inc
+++ b/recipes-core/acrn/acrn-common.inc
@@ -5,13 +5,14 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=ba07c9571f2096ec6349ef0167ec5e60"
 
 SRC_URI = "git://github.com/projectacrn/acrn-hypervisor.git;protocol=https;branch=${SRCBRANCH}; \
            git://github.com/intel-innersource/virtualization.hypervisors.acrn.acrn-dev.acrn-offline-patch.git;protocol=https;branch=master;destsuffix=offline-patches;name=innersrc \
+           file://0001-Makefile-disable-Werror-option-for-now.patch \
 "
 
 # Snapshot tags are of the format:
 # acrn-<year>w<week>.<day>-<timestamp><pass|fail>
 PV = "3.0"
-SRCREV = "f8f1689a887fd377ec7acf224a4513465545500a"
-SRCREV_innersrc = "96ebf90cfccd7abf7d9943431f06d2e56aa202f0"
+SRCREV = "df3390f4014bc707a7c301843240af6ae357edc0"
+SRCREV_innersrc = "045ff4172396a5675cb0b8958efd383885f6e26f"
 SRCBRANCH = "master"
 
 UPSTREAM_CHECK_GITTAGREGEX = "^v(?P<pver>\d+(\.\d+)+)$"

--- a/recipes-core/acrn/files/0001-Makefile-disable-Werror-option-for-now.patch
+++ b/recipes-core/acrn/files/0001-Makefile-disable-Werror-option-for-now.patch
@@ -1,0 +1,48 @@
+From 4cf3a61a3eeab0c7a3726d624104ff0f327094b1 Mon Sep 17 00:00:00 2001
+From: Naveen Saini <naveen.kumar.saini@intel.com>
+Date: Fri, 13 May 2022 22:47:08 +0800
+Subject: [PATCH] Makefile: disable -Werror option for now
+
+GCC12 causing multiple warnings which are currently being treated as error.
+
+Ignore for now, untill not fixed upstream.
+
+Issue raised: https://github.com/projectacrn/acrn-hypervisor/issues/7453
+
+Upstream-Status: Inappropriate
+
+Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>
+---
+ devicemodel/Makefile             | 2 +-
+ misc/services/life_mngr/Makefile | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/devicemodel/Makefile b/devicemodel/Makefile
+index 3fcd1dd55..c08593f2a 100644
+--- a/devicemodel/Makefile
++++ b/devicemodel/Makefile
+@@ -28,7 +28,7 @@ CFLAGS += -D_GNU_SOURCE
+ CFLAGS += -DNO_OPENSSL
+ CFLAGS += -m64
+ CFLAGS += -Wall -ffunction-sections
+-CFLAGS += -Werror
++#CFLAGS += -Werror
+ CFLAGS += -O2 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2
+ CFLAGS += -Wformat -Wformat-security -fno-strict-aliasing
+ CFLAGS += -fno-delete-null-pointer-checks -fwrapv
+diff --git a/misc/services/life_mngr/Makefile b/misc/services/life_mngr/Makefile
+index b2992d447..151f9afaf 100644
+--- a/misc/services/life_mngr/Makefile
++++ b/misc/services/life_mngr/Makefile
+@@ -8,7 +8,7 @@ LIFEMNGR_CFLAGS += -D_GNU_SOURCE
+ LIFEMNGR_CFLAGS += -DNO_OPENSSL
+ LIFEMNGR_CFLAGS += -m64
+ LIFEMNGR_CFLAGS += -Wall -ffunction-sections
+-LIFEMNGR_CFLAGS += -Werror
++#LIFEMNGR_CFLAGS += -Werror
+ LIFEMNGR_CFLAGS += -O2 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2
+ LIFEMNGR_CFLAGS += -Wformat -Wformat-security -fno-strict-aliasing
+ LIFEMNGR_CFLAGS += -fno-delete-null-pointer-checks -fwrapv
+-- 
+2.25.1
+


### PR DESCRIPTION
Disable -Werror option for now. GCC12 causing multiple
warnings which are currently being treated as error.

Ignore for now, untill not fixed upstream.

Issue raised: https://github.com/projectacrn/acrn-hypervisor/issues/7453

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>