### PR TITLE
linux-intel-acrn/5.10: update to v5.10.115

### DIFF
--- a/recipes-kernel/linux/files/0001-regulator-consumer-Add-missing-stubs-to-regulator-co.patch
+++ b/recipes-kernel/linux/files/0001-regulator-consumer-Add-missing-stubs-to-regulator-co.patch
@@ -1,0 +1,89 @@
+From 1c80d994d3dbdaefb429305461e95a86be5b3862 Mon Sep 17 00:00:00 2001
+From: Dmitry Osipenko <digetx@gmail.com>
+Date: Tue, 10 May 2022 16:53:06 +0800
+Subject: [PATCH] regulator: consumer: Add missing stubs to
+ regulator/consumer.h
+
+commit 51dfb6ca3728bd0a0a3c23776a12d2a15a1d2457 upstream
+
+Add missing stubs to regulator/consumer.h in order to fix COMPILE_TEST
+of the kernel. In particular this should fix compile-testing of OPP core
+because of a missing stub for regulator_sync_voltage().
+
+Reported-by: kernel test robot <lkp@intel.com>
+Signed-off-by: Dmitry Osipenko <digetx@gmail.com>
+Link: https://lore.kernel.org/r/20210120205844.12658-1-digetx@gmail.com
+Signed-off-by: Mark Brown <broonie@kernel.org>
+
+Backport from mainline to fix build failure when CONFIG_REGULATOR=n which
+is default in linux-yocto.
+5.10.114 in mainline stable tree does not handle this case.
+Link: https://lore.kernel.org/all/62796b82.1c69fb81.1bf47.0bcf@mx.google.com/
+
+Upstream-Status: Backported [https://github.com/torvalds/linux/commit/51dfb6ca3728bd0a0a3c23776a12d2a15a1d2457]
+
+Signed-off-by: He Zhe <zhe.he@windriver.com>
+Signed-off-by: Bruce Ashfield <bruce.ashfield@gmail.com>
+Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>
+---
+ include/linux/regulator/consumer.h | 30 ++++++++++++++++++++++++++++++
+ 1 file changed, 30 insertions(+)
+
+diff --git a/include/linux/regulator/consumer.h b/include/linux/regulator/consumer.h
+index 2024944fd2f7..20e84a84fb77 100644
+--- a/include/linux/regulator/consumer.h
++++ b/include/linux/regulator/consumer.h
+@@ -331,6 +331,12 @@ regulator_get_exclusive(struct device *dev, const char *id)
+ 	return ERR_PTR(-ENODEV);
+ }
+ 
++static inline struct regulator *__must_check
++devm_regulator_get_exclusive(struct device *dev, const char *id)
++{
++	return ERR_PTR(-ENODEV);
++}
++
+ static inline struct regulator *__must_check
+ regulator_get_optional(struct device *dev, const char *id)
+ {
+@@ -486,6 +492,11 @@ static inline int regulator_get_voltage(struct regulator *regulator)
+ 	return -EINVAL;
+ }
+ 
++static inline int regulator_sync_voltage(struct regulator *regulator)
++{
++	return -EINVAL;
++}
++
+ static inline int regulator_is_supported_voltage(struct regulator *regulator,
+ 				   int min_uV, int max_uV)
+ {
+@@ -578,6 +589,25 @@ static inline int devm_regulator_unregister_notifier(struct regulator *regulator
+ 	return 0;
+ }
+ 
++static inline int regulator_suspend_enable(struct regulator_dev *rdev,
++					   suspend_state_t state)
++{
++	return -EINVAL;
++}
++
++static inline int regulator_suspend_disable(struct regulator_dev *rdev,
++					    suspend_state_t state)
++{
++	return -EINVAL;
++}
++
++static inline int regulator_set_suspend_voltage(struct regulator *regulator,
++						int min_uV, int max_uV,
++						suspend_state_t state)
++{
++	return -EINVAL;
++}
++
+ static inline void *regulator_get_drvdata(struct regulator *regulator)
+ {
+ 	return NULL;
+-- 
+2.25.1
+

--- a/recipes-kernel/linux/linux-intel-acrn_5.10.inc
+++ b/recipes-kernel/linux/linux-intel-acrn_5.10.inc
@@ -2,16 +2,17 @@ SUMMARY = "Linux Kernel 5.10 with ACRN enabled"
 
 require recipes-kernel/linux/linux-intel.inc
 
-SRC_URI:append = "  file://0001-menuconfig-mconf-cfg-Allow-specification-of-ncurses-.patch"
+SRC_URI:append = "  file://0001-menuconfig-mconf-cfg-Allow-specification-of-ncurses-.patch \
+                    file://0001-regulator-consumer-Add-missing-stubs-to-regulator-co.patch"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
 KBRANCH = "5.10/yocto"
 KMETA_BRANCH = "yocto-5.10"
 
-LINUX_VERSION ?= "5.10.109"
-SRCREV_machine ?= "6410aba3b60feba47b9713f297d9b3bdb79981f5"
-SRCREV_meta ?= "19e7547dd6617760d6094b7a42da1a718b5a96ee"
+LINUX_VERSION ?= "5.10.115"
+SRCREV_machine ?= "6d2c1213aa7e48623e06ec2243a390bfb2f86ecd"
+SRCREV_meta ?= "6337d56f23d18e5680493dadcb52899d5e6a7c09"
 
 DEPENDS += "elfutils-native openssl-native util-linux-native"
 

--- a/recipes-kernel/linux/linux-intel-rt-acrn-uos_5.10.bb
+++ b/recipes-kernel/linux/linux-intel-rt-acrn-uos_5.10.bb
@@ -10,6 +10,7 @@ python () {
 }
 
 SRC_URI:append = "  file://0001-menuconfig-mconf-cfg-Allow-specification-of-ncurses-.patch \
+                    file://0001-regulator-consumer-Add-missing-stubs-to-regulator-co.patch \
                     file://uos_rt_5.10.scc \
 "
 
@@ -20,9 +21,9 @@ KMETA_BRANCH = "yocto-5.10"
 
 DEPENDS += "elfutils-native openssl-native util-linux-native"
 
-LINUX_VERSION ?= "5.10.109"
-SRCREV_machine ?= "1a9009a376865b4c0d381b8cd683ca9a10b5a09a"
-SRCREV_meta ?= "19e7547dd6617760d6094b7a42da1a718b5a96ee"
+LINUX_VERSION ?= "5.10.115"
+SRCREV_machine ?= "319577bba3954e68f22144f28d3e6191c2d953d7"
+SRCREV_meta ?= "6337d56f23d18e5680493dadcb52899d5e6a7c09"
 
 LINUX_VERSION_EXTENSION = "-linux-intel-preempt-rt-acrn-uos"
 

--- a/recipes-kernel/linux/linux-intel-rt-acrn-uos_5.4.bb
+++ b/recipes-kernel/linux/linux-intel-rt-acrn-uos_5.4.bb
@@ -20,8 +20,8 @@ KMETA_BRANCH = "yocto-5.4"
 
 DEPENDS += "elfutils-native openssl-native util-linux-native"
 
-LINUX_VERSION ?= "5.4.177"
-SRCREV_machine ?= "7234dd7d1a1b3d6e3dee299383f25adfd542db33"
+LINUX_VERSION ?= "5.4.193"
+SRCREV_machine ?= "5776551e21679ed5fec50abbdf4627920b4103b1"
 SRCREV_meta ?= "337c38059f2fd562199b0e5133b71410240004e9"
 
 LINUX_VERSION_EXTENSION = "-linux-intel-preempt-rt-acrn-uos"


### PR DESCRIPTION
f226b95 linux-intel-rt-acrn-uos/5.4 : update to 5.4.193-rt74
0c74fc3 linux-intel-rt-acrn-uos : update to 5.10.115-rt67
1b0cf25 linux-intel-acrn/5.10: update to v5.10.115

