### PR TITLE
Backport patches from master

### DIFF
--- a/conf/distro/acrn-demo-sos.conf
+++ b/conf/distro/acrn-demo-sos.conf
@@ -25,3 +25,6 @@ APPEND += " ${LINUX_GVT_APPEND}"
 EFI_PROVIDER = "grub-efi"
 GRUB_BUILDIN:append = " multiboot2 "
 WKS_FILE = "${@bb.utils.contains_any("IMAGE_CLASSES", "dm-verity-img", "acrn-bootdisk-dmverity.wks.in", "acrn-bootdisk-microcode.wks.in", d)}"
+
+# Disable auto ethernet DHCP as its handled by ACRN tools
+PACKAGECONFIG:remove:pn-systemd-conf = "dhcp-ethernet"

--- a/conf/distro/include/acrn-demo.inc
+++ b/conf/distro/include/acrn-demo.inc
@@ -1,6 +1,6 @@
 DISTRO = "acrn-demo"
 DISTRO_NAME = "ACRN Demo"
-DISTRO_VERSION = "3.1+snapshot-${DATE}"
+DISTRO_VERSION = "4.0+snapshot-${DATE}"
 
 DISTRO_FEATURES = "${DISTRO_FEATURES_DEFAULT} \
                    systemd efi largefile opengl ptest multiarch \


### PR DESCRIPTION
acrn-demo-sos.conf: Disable auto ethernet DHCP

DHCP is already enabled & handled by ACRN bridge services, which
causes conflict with it. Due to that user VM do not get
IP address. So disable it, let ACRN tools handle it.

https://git.yoctoproject.org/poky/tree/meta/recipes-core/systemd/systemd-conf_1.0.bb#n26
https://github.com/projectacrn/acrn-hypervisor/tree/release_3.0/misc/services/acrn_bridge

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>

##########################################################################

acrn-demo.inc: Version bump to 4.0

Bump version post kirkstone release

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>



