### PR TITLE
acrn-libvirt: update to include latest commits

### DIFF
--- a/dynamic-layers/virtualization-layer/recipes-extended/libvirt/acrn-libvirt_6.1.0.bb
+++ b/dynamic-layers/virtualization-layer/recipes-extended/libvirt/acrn-libvirt_6.1.0.bb
@@ -46,7 +46,7 @@ SRC_URI = "git://github.com/projectacrn/acrn-libvirt.git;protocol=https;branch=$
 
 SRCBRANCH = "dev-acrn-v6.1.0"
 # with acrn v6.1.0
-SRCREV_libvirt = "897b25800f17c46f960e66e45d9862e92d3af551"
+SRCREV_libvirt = "3cc935eb451d363bff886dd57e42a47a83eeec22"
 SRCREV_keycodemapdb = "27acf0ef828bf719b2053ba398b195829413dbdd"
 
 inherit autotools gettext update-rc.d pkgconfig ptest systemd useradd perlnative


### PR DESCRIPTION
It includes:
acrn-driver: ethernet parameter modify
acrn-driver: add vCPU info for `acrn:cpu_affinity`
acrn-driver: allocate vCPU for Guest VM
acrn-driver: mapping processor and apicid
acrn_domain : add cpu_affinity to check list
acrn-driver: pass `--rtvm` to acrn-dm instead of `--lapic_pt`
acrn-driver: add CPU affinity support
acrn-driver: support user VM reboot
acrn-driver: support shutdown user VM gracefully
acrn-driver: support vm destroy and force shutdown
acrn-driver: remove acrn-dm param `-A`

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>