### PR TITLE
linux-intel-acrn-service-vm/5.15: add recipe for service VM

### DIFF
--- a/recipes-kernel/linux/files/service-vm_5.15.cfg
+++ b/recipes-kernel/linux/files/service-vm_5.15.cfg
@@ -1,0 +1,1 @@
+# Place Holder for 5.15 Service VM specific configs

--- a/recipes-kernel/linux/files/service-vm_5.15.scc
+++ b/recipes-kernel/linux/files/service-vm_5.15.scc
@@ -1,0 +1,7 @@
+define KFEATURE_DESCRIPTION "Add required kernel features for 5.15 Service VM kernel"
+define KFEATURE_COMPATIBILITY board
+
+kconf non-hardware acrn-common.cfg
+kconf non-hardware service-vm.cfg
+kconf non-hardware service-vm_5.10.cfg
+kconf non-hardware service-vm_5.15.cfg

--- a/recipes-kernel/linux/files/user-rtvm_5.15.scc
+++ b/recipes-kernel/linux/files/user-rtvm_5.15.scc
@@ -1,0 +1,8 @@
+define KFEATURE_DESCRIPTION "Add required kernel features for 5.10 User VM Preempt RT kernel"
+define KFEATURE_COMPATIBILITY board
+
+kconf non-hardware acrn-common.cfg
+kconf non-hardware user-vm.cfg
+kconf non-hardware user-vm_5.10.cfg
+kconf non-hardware user-vm_5.15.cfg
+kconf non-hardware user-rtvm.cfg

--- a/recipes-kernel/linux/files/user-vm_5.15.cfg
+++ b/recipes-kernel/linux/files/user-vm_5.15.cfg
@@ -1,0 +1,1 @@
+# Place Holder for 5.15 User VM specific configs

--- a/recipes-kernel/linux/files/user-vm_5.15.scc
+++ b/recipes-kernel/linux/files/user-vm_5.15.scc
@@ -1,0 +1,7 @@
+define KFEATURE_DESCRIPTION "Add required kernel features for 5.15 User VM kernel"
+define KFEATURE_COMPATIBILITY board
+
+kconf non-hardware acrn-common.cfg
+kconf non-hardware user-vm.cfg
+kconf non-hardware user-vm_5.10.cfg
+kconf non-hardware user-vm_5.15.cfg

--- a/recipes-kernel/linux/linux-intel-acrn-rtvm_5.15.bb
+++ b/recipes-kernel/linux/linux-intel-acrn-rtvm_5.15.bb
@@ -1,0 +1,41 @@
+SUMMARY = "Linux Preempt RT Kernel with ACRN enabled (User VM)"
+
+require recipes-kernel/linux/linux-intel.inc
+
+# PREFERRED_PROVIDER for virtual/kernel. This avoids errors when trying
+# to build multiple virtual/kernel providers.
+python () {
+    if d.getVar("KERNEL_PACKAGE_NAME", True) == "kernel" and d.getVar("PREFERRED_PROVIDER_virtual/kernel") != "linux-intel-acrn-rtvm":
+        raise bb.parse.SkipPackage("Set PREFERRED_PROVIDER_virtual/kernel to linux-intel-acrn-rtvm to enable it")
+}
+
+SRC_URI:append = "  file://0001-menuconfig-mconf-cfg-Allow-specification-of-ncurses-.patch \
+                    file://user-rtvm_5.15.scc \
+"
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
+
+KBRANCH = "5.15/preempt-rt"
+KMETA_BRANCH = "yocto-5.15"
+
+DEPENDS += "elfutils-native openssl-native util-linux-native"
+
+LINUX_VERSION ?= "5.15.49"
+SRCREV_machine ?= "56b60d58176fd42978fa3418a962fe4a038d164f"
+SRCREV_meta ?= "d9823ca27110545274f77718aefbd809c29947e6"
+
+LINUX_VERSION_EXTENSION = "-linux-intel-acrn-preempt-rtvm"
+
+LINUX_KERNEL_TYPE = "preempt-rt"
+
+KERNEL_FEATURES:append = " features/netfilter/netfilter.scc \
+                          features/security/security.scc  \
+                          cfg/hv-guest.scc \
+                          cfg/paravirt_kvm.scc \
+                          features/net/stmicro/stmmac.cfg \
+"
+# Following commit is backported from mainline 5.19 to linux-intel 5.15 kernel
+# Commit: https://github.com/torvalds/linux/commit/8b766b0f8eece55155146f7628610ce54a065e0f
+# In which 'CONFIG_FB_BOOT_VESA_SUPPORT' config option is dropped.
+# This causes warning during config audit. So suppress the harmless warning for now.
+KCONF_BSP_AUDIT_LEVEL = "0"

--- a/recipes-kernel/linux/linux-intel-acrn-service-vm_5.15.bb
+++ b/recipes-kernel/linux/linux-intel-acrn-service-vm_5.15.bb
@@ -1,0 +1,17 @@
+require linux-intel-acrn_5.15.inc
+
+SRC_URI:append = " file://service-vm_5.15.scc"
+
+LINUX_VERSION_EXTENSION = "-linux-intel-acrn-service-vm"
+
+SUMMARY = "Linux Kernel with ACRN enabled (Service VM)"
+
+KERNEL_FEATURES:append = " features/criu/criu-enable.scc \
+                          cgl/cfg/iscsi.scc \
+                          service-vm_5.15.scc \
+"
+
+# config warning:  'CONFIG_IRQ_REMAP' last val (y) and .config val (n) do not matchs
+# It is because, CONFIG_IRQ_REMAP depends upon IOMMU_SUPPORT, which we are explicitly disabling by setting to 'n'
+# So, to suppress this warning, set
+KCONF_AUDIT_LEVEL = "0"

--- a/recipes-kernel/linux/linux-intel-acrn-user-vm_5.15.bb
+++ b/recipes-kernel/linux/linux-intel-acrn-user-vm_5.15.bb
@@ -1,0 +1,7 @@
+require linux-intel-acrn_5.15.inc
+
+SRC_URI:append = "  file://user-vm_5.15.scc"
+
+LINUX_VERSION_EXTENSION = "-linux-intel-acrn-user-vm"
+
+SUMMARY = "Linux Kernel with ACRN enabled (User VM)"

--- a/recipes-kernel/linux/linux-intel-acrn_5.15.inc
+++ b/recipes-kernel/linux/linux-intel-acrn_5.15.inc
@@ -1,0 +1,29 @@
+SUMMARY = "Linux Kernel 5.15 with ACRN enabled"
+
+require recipes-kernel/linux/linux-intel.inc
+
+SRC_URI:append = "  file://0001-menuconfig-mconf-cfg-Allow-specification-of-ncurses-.patch \
+                 "
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
+
+KBRANCH = "5.15/linux"
+KMETA_BRANCH = "yocto-5.15"
+
+LINUX_VERSION ?= "5.15.49"
+SRCREV_machine ?= "db21c2106e1609b1305b5190d6b54e5c473a4570"
+SRCREV_meta ?= "d9823ca27110545274f77718aefbd809c29947e6"
+
+DEPENDS += "elfutils-native openssl-native util-linux-native"
+
+KERNEL_FEATURES:append = " features/netfilter/netfilter.scc \
+                          features/security/security.scc  \
+                          cfg/hv-guest.scc \
+                          cfg/paravirt_kvm.scc \
+                          features/net/stmicro/stmmac.cfg \
+"
+# Following commit is backported from mainline 5.19 to linux-intel 5.15 kernel
+# Commit: https://github.com/torvalds/linux/commit/8b766b0f8eece55155146f7628610ce54a065e0f
+# In which 'CONFIG_FB_BOOT_VESA_SUPPORT' config option is dropped.
+# This causes warning during config audit. So suppress the harmless warning for now.
+KCONF_BSP_AUDIT_LEVEL = "0"


### PR DESCRIPTION
linux-intel-acrn-service-vm/5.15: add recipe for service VM

Add linux-intel-acrn-user-vm/5.15 kernel recipe for User VM too.

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>


##########################################################

linux-intel-acrn-rtvm/5.15: add recipe for RTVM

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>

