### PR TITLE
acrn-life-mngr: install life_mngr.conf

### DIFF
--- a/recipes-core/acrn/acrn-life-mngr.bb
+++ b/recipes-core/acrn/acrn-life-mngr.bb
@@ -13,6 +13,8 @@ do_compile() {
 do_install() {
 	install -d ${D}${bindir}
 	install -m 0755 ${B}/life_mngr ${D}${bindir}
+	install -d ${D}${sysconfdir}/life_mngr
+	install -m 0644 ${B}/life_mngr.conf ${D}${sysconfdir}/life_mngr/
 	install -d ${D}${systemd_unitdir}/system/
 	install -m 0644 ${B}/life_mngr.service ${D}${systemd_unitdir}/system/
 }


### PR DESCRIPTION
It fixes life_mngr.service failure.

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>