### PR TITLE
Backport kernel 5.15 patches

### DIFF
--- a/recipes-core/acrn/acrn-common.inc
+++ b/recipes-core/acrn/acrn-common.inc
@@ -10,10 +10,10 @@ SRC_URI = "git://github.com/projectacrn/acrn-hypervisor.git;protocol=https;branc
 
 # Snapshot tags are of the format:
 # acrn-<year>w<week>.<day>-<timestamp><pass|fail>
-PV = "3.1"
-SRCREV = "7fad37e0259af8c13779f33b24cadaf78f043f2b"
-SRCREV_innersrc = "eb40968840fb415f583a840b837ae79ff28630b5"
-SRCBRANCH = "release_3.1"
+PV = "3.2"
+SRCREV = "c526cbebf1e619d2475cafb63d6573104b9070d2"
+SRCREV_innersrc = "e30c6f09f1a3d4f35ce84b11c2ce3ed912274efe"
+SRCBRANCH = "master"
 
 UPSTREAM_CHECK_GITTAGREGEX = "^v(?P<pver>\d+(\.\d+)+)$"
 

--- a/recipes-core/acrn/acrn-common.inc
+++ b/recipes-core/acrn/acrn-common.inc
@@ -11,7 +11,7 @@ SRC_URI = "git://github.com/projectacrn/acrn-hypervisor.git;protocol=https;branc
 # Snapshot tags are of the format:
 # acrn-<year>w<week>.<day>-<timestamp><pass|fail>
 PV = "3.1"
-SRCREV = "f4dec5a554730c8adf5755a29593558f65d28f79"
+SRCREV = "7fad37e0259af8c13779f33b24cadaf78f043f2b"
 SRCREV_innersrc = "eb40968840fb415f583a840b837ae79ff28630b5"
 SRCBRANCH = "release_3.1"
 

--- a/recipes-core/acrn/acrn-hypervisor.bb
+++ b/recipes-core/acrn/acrn-hypervisor.bb
@@ -14,7 +14,7 @@ inherit python3native deploy
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
-DEPENDS += "acrn-hypervisor-native acpica-native python3-lxml-native gnu-efi python3-defusedxml-native python3-elementpath-native"
+DEPENDS += "acrn-hypervisor-native acpica-native python3-lxml-native gnu-efi python3-defusedxml-native python3-elementpath-native python3-xmlschema-native"
 
 # parallel build could face build failure in case of config-tool method:
 #    | .config does not exist and no defconfig available for BOARD...
@@ -79,7 +79,7 @@ do_deploy() {
 INSANE_SKIP:${PN} += "arch already-stripped"
 
 do_compile:class-native() {
-	oe_runmake -C hypervisor pre_build
+	oe_runmake -C hypervisor
 }
 
 do_install:class-native(){

--- a/recipes-core/acrn/acrn-hypervisor/hypervisor-dont-build-pre_build.patch
+++ b/recipes-core/acrn/acrn-hypervisor/hypervisor-dont-build-pre_build.patch
@@ -1,6 +1,6 @@
-From 5a1bee51c096107f994854ae1ac14b138caef75c Mon Sep 17 00:00:00 2001
+From 76d64dc958e0668be4032a1448d05cb9e33fecfa Mon Sep 17 00:00:00 2001
 From: Naveen Saini <naveen.kumar.saini@intel.com>
-Date: Thu, 14 Jul 2022 17:56:18 +0800
+Date: Tue, 1 Nov 2022 12:41:51 +0800
 Subject: [PATCH] Execute pre_build_check during hypervisor build is causing
  error
 
@@ -16,19 +16,19 @@ Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>
  1 file changed, 3 deletions(-)
 
 diff --git a/hypervisor/Makefile b/hypervisor/Makefile
-index bd45b539f..db67782e1 100644
+index cd49ae28c..bead223b6 100644
 --- a/hypervisor/Makefile
 +++ b/hypervisor/Makefile
-@@ -423,9 +423,6 @@ endif
+@@ -424,9 +424,6 @@ $(error Please either install "iasl" or provide the path to "iasl" by using the
+ endif
  
- .PHONY: pre_build
- pre_build: $(HV_CONFIG_H) $(HV_CONFIG_TIMESTAMP)
+ $(PRE_BUILD_CHECKER): $(HV_CONFIG_H) $(HV_CONFIG_TIMESTAMP)
 -	@echo "Start pre-build static check ..."
--	$(MAKE) -C $(PRE_BUILD_DIR) BOARD=$(BOARD) SCENARIO=$(SCENARIO) TARGET_DIR=$(HV_CONFIG_DIR)
--	@$(HV_OBJDIR)/hv_prebuild_check.out
+-	$(MAKE) -C $(PRE_BUILD_DIR) BOARD=$(BOARD) SCENARIO=$(SCENARIO) CHECKER_OUT=$(PRE_BUILD_CHECKER)
+-	@$(PRE_BUILD_CHECKER)
+ 
+ $(HV_ACPI_TABLE_TIMESTAMP): $(HV_CONFIG_TIMESTAMP)
  	@echo "generate the binary of ACPI tables for pre-launched VMs ..."
- 	python3 ../misc/config_tools/acpi_gen/bin_gen.py --board $(HV_OBJDIR)/.board.xml --scenario $(HV_OBJDIR)/.scenario.xml --asl $(HV_CONFIG_DIR) --out $(HV_OBJDIR) --iasl_path $(ASL_COMPILER) --iasl_min_ver $(IASL_MIN_VER)
- 	@echo "generate the serial configuration file for service VM ..."
 -- 
 2.25.1
 

--- a/recipes-kernel/linux/linux-intel-acrn-rtvm_5.15.bb
+++ b/recipes-kernel/linux/linux-intel-acrn-rtvm_5.15.bb
@@ -1,0 +1,41 @@
+SUMMARY = "Linux Preempt RT Kernel with ACRN enabled (User VM)"
+
+require recipes-kernel/linux/linux-intel.inc
+
+# PREFERRED_PROVIDER for virtual/kernel. This avoids errors when trying
+# to build multiple virtual/kernel providers.
+python () {
+    if d.getVar("KERNEL_PACKAGE_NAME", True) == "kernel" and d.getVar("PREFERRED_PROVIDER_virtual/kernel") != "linux-intel-acrn-rtvm":
+        raise bb.parse.SkipPackage("Set PREFERRED_PROVIDER_virtual/kernel to linux-intel-acrn-rtvm to enable it")
+}
+
+SRC_URI:append = "  file://0001-menuconfig-mconf-cfg-Allow-specification-of-ncurses-.patch \
+                    file://user-rtvm_5.15.scc \
+"
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
+
+KBRANCH = "5.15/preempt-rt"
+KMETA_BRANCH = "yocto-5.15"
+
+DEPENDS += "elfutils-native openssl-native util-linux-native"
+
+LINUX_VERSION ?= "5.15.49"
+SRCREV_machine ?= "56b60d58176fd42978fa3418a962fe4a038d164f"
+SRCREV_meta ?= "d9823ca27110545274f77718aefbd809c29947e6"
+
+LINUX_VERSION_EXTENSION = "-linux-intel-acrn-preempt-rtvm"
+
+LINUX_KERNEL_TYPE = "preempt-rt"
+
+KERNEL_FEATURES:append = " features/netfilter/netfilter.scc \
+                          features/security/security.scc  \
+                          cfg/hv-guest.scc \
+                          cfg/paravirt_kvm.scc \
+                          features/net/stmicro/stmmac.cfg \
+"
+# Following commit is backported from mainline 5.19 to linux-intel 5.15 kernel
+# Commit: https://github.com/torvalds/linux/commit/8b766b0f8eece55155146f7628610ce54a065e0f
+# In which 'CONFIG_FB_BOOT_VESA_SUPPORT' config option is dropped.
+# This causes warning during config audit. So suppress the harmless warning for now.
+KCONF_BSP_AUDIT_LEVEL = "0"

--- a/recipes-kernel/linux/linux-intel-acrn-service-vm_5.15.bb
+++ b/recipes-kernel/linux/linux-intel-acrn-service-vm_5.15.bb
@@ -1,0 +1,17 @@
+require linux-intel-acrn_5.15.inc
+
+SRC_URI:append = " file://service-vm_5.15.scc"
+
+LINUX_VERSION_EXTENSION = "-linux-intel-acrn-service-vm"
+
+SUMMARY = "Linux Kernel with ACRN enabled (Service VM)"
+
+KERNEL_FEATURES:append = " features/criu/criu-enable.scc \
+                          cgl/cfg/iscsi.scc \
+                          service-vm_5.15.scc \
+"
+
+# config warning:  'CONFIG_IRQ_REMAP' last val (y) and .config val (n) do not matchs
+# It is because, CONFIG_IRQ_REMAP depends upon IOMMU_SUPPORT, which we are explicitly disabling by setting to 'n'
+# So, to suppress this warning, set
+KCONF_AUDIT_LEVEL = "0"

--- a/recipes-kernel/linux/linux-intel-acrn-user-vm_5.15.bb
+++ b/recipes-kernel/linux/linux-intel-acrn-user-vm_5.15.bb
@@ -1,0 +1,7 @@
+require linux-intel-acrn_5.15.inc
+
+SRC_URI:append = "  file://user-vm_5.15.scc"
+
+LINUX_VERSION_EXTENSION = "-linux-intel-acrn-user-vm"
+
+SUMMARY = "Linux Kernel with ACRN enabled (User VM)"

--- a/recipes-kernel/linux/linux-intel-acrn_5.15.inc
+++ b/recipes-kernel/linux/linux-intel-acrn_5.15.inc
@@ -1,0 +1,29 @@
+SUMMARY = "Linux Kernel 5.15 with ACRN enabled"
+
+require recipes-kernel/linux/linux-intel.inc
+
+SRC_URI:append = "  file://0001-menuconfig-mconf-cfg-Allow-specification-of-ncurses-.patch \
+                 "
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
+
+KBRANCH = "5.15/linux"
+KMETA_BRANCH = "yocto-5.15"
+
+LINUX_VERSION ?= "5.15.49"
+SRCREV_machine ?= "db21c2106e1609b1305b5190d6b54e5c473a4570"
+SRCREV_meta ?= "d9823ca27110545274f77718aefbd809c29947e6"
+
+DEPENDS += "elfutils-native openssl-native util-linux-native"
+
+KERNEL_FEATURES:append = " features/netfilter/netfilter.scc \
+                          features/security/security.scc  \
+                          cfg/hv-guest.scc \
+                          cfg/paravirt_kvm.scc \
+                          features/net/stmicro/stmmac.cfg \
+"
+# Following commit is backported from mainline 5.19 to linux-intel 5.15 kernel
+# Commit: https://github.com/torvalds/linux/commit/8b766b0f8eece55155146f7628610ce54a065e0f
+# In which 'CONFIG_FB_BOOT_VESA_SUPPORT' config option is dropped.
+# This causes warning during config audit. So suppress the harmless warning for now.
+KCONF_BSP_AUDIT_LEVEL = "0"


### PR DESCRIPTION
f9ef2fd acrn: upgrade to v3.2
929e4fb linux-intel-acrn-rtvm/5.15: add recipe for RTVM
fc51235 linux-intel-acrn-service-vm/5.15: add recipe for service VM
20db93c acrn: upgrade to releaes tag v3.1
