### PR TITLE
linux-intel-acrn/5.15: fix SRC_URI

### DIFF
--- a/recipes-kernel/linux/linux-intel-acrn-rtvm_5.15.bb
+++ b/recipes-kernel/linux/linux-intel-acrn-rtvm_5.15.bb
@@ -9,6 +9,9 @@ python () {
         raise bb.parse.SkipPackage("Set PREFERRED_PROVIDER_virtual/kernel to linux-intel-acrn-rtvm to enable it")
 }
 
+SRC_URI:prepend = "git://github.com/intel/linux-intel-lts.git;protocol=https;name=machine;branch=${KBRANCH}; \
+                    "
+
 SRC_URI:append = "  file://0001-menuconfig-mconf-cfg-Allow-specification-of-ncurses-.patch \
                     file://user-rtvm_5.15.scc \
 "

--- a/recipes-kernel/linux/linux-intel-acrn_5.15.inc
+++ b/recipes-kernel/linux/linux-intel-acrn_5.15.inc
@@ -2,6 +2,8 @@ SUMMARY = "Linux Kernel 5.15 with ACRN enabled"
 
 require recipes-kernel/linux/linux-intel.inc
 
+SRC_URI:prepend = "git://github.com/intel/linux-intel-lts.git;protocol=https;name=machine;branch=${KBRANCH}; \
+                    "
 SRC_URI:append = "  file://0001-menuconfig-mconf-cfg-Allow-specification-of-ncurses-.patch \
                  "
 


### PR DESCRIPTION
Added linux-intel-lts repo path, its required due to recent changes in meta-intel layer.

https://git.yoctoproject.org/meta-intel/commit/?id=2ce9b55f99a30e810aed196888c0858f4996e26e

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>