### PR TITLE
layer.conf: update LAYERSERIES_COMPAT for mickledore

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -8,7 +8,7 @@ BBFILE_PATTERN_meta-acrn = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-acrn = "5"
 
 LAYERDEPENDS_meta-acrn = "core intel meta-python"
-LAYERSERIES_COMPAT_meta-acrn = "kirkstone langdale"
+LAYERSERIES_COMPAT_meta-acrn = "kirkstone langdale mickledore"
 
 BBFILES_DYNAMIC += " \
     virtualization-layer:${LAYERDIR}/dynamic-layers/virtualization-layer/*/*/*.bb \


### PR DESCRIPTION
* oe-core switched to mickedore in: https://git.openembedded.org/openembedded-core/commit/?id=57239d66b933c4313cf331d35d13ec2d0661c38f

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>