### PR TITLE
python3-elementpath/3.0.2: add recipe

### DIFF
--- a/conf/distro/acrn-demo-service-vm.conf
+++ b/conf/distro/acrn-demo-service-vm.conf
@@ -17,6 +17,18 @@ PREFERRED_PROVIDER_nativesdk-libvirt = "nativesdk-acrn-libvirt"
 PREFERRED_VERSION_python3-docutils = "0.16"
 PREFERRED_VERSION_python3-docutils-native = "0.16"
 
+# elementpath 4.0.1 has removed 'SYMBOLS' attribute, which causing failure in ACRN 3.1.0
+# https://github.com/sissaschool/elementpath/commit/a76aeb88b0d103420239df1d5d001f7d7f56b5c9
+#
+# misc/config_tools/scenario_config/elementpath_overlay.py", line 24, in CustomParser
+#|     SYMBOLS = BaseParser.SYMBOLS | {
+#|               ^^^^^^^^^^^^^^^^^^
+#| AttributeError: type object 'XPath2Parser' has no attribute 'SYMBOLS'
+# Carry python3-elementpath 3.0.2 version locally, until it gets fixed upstream
+PREFERRED_VERSION_python3-elementpath = "3.0.2"
+PREFERRED_VERSION_python3-elementpath-native = "3.0.2"
+
+
 
 # ACRN hypervisor log setting, sensible defaults
 LINUX_ACRN_APPEND ?= "hvlog=2M@0xE00000 ${@bb.utils.contains('EFI_PROVIDER','grub-efi','memmap=2M\$0xE00000','memmap=2M$0xE00000',d)} "

--- a/recipes-devtools/python/python3-elementpath_3.0.2.bb
+++ b/recipes-devtools/python/python3-elementpath_3.0.2.bb
@@ -1,0 +1,19 @@
+DESCRIPTION = "Provide XPath 1.0 and 2.0 selectors for Python's ElementTree XML data structures, both for the standard ElementTree library and for the lxml.etree library."
+HOMEPAGE = "https://github.com/sissaschool/elementpath"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=5dbb7fb7d72da3921202dd7b995d3ecf"
+
+SRC_URI[sha256sum] = "cca18742dc0f354f79874c41a906e6ce4cc15230b7858d22a861e1ec5946940f"
+
+PYPI_PACKAGE = "elementpath"
+inherit pypi setuptools3
+
+RDEPENDS:${PN} += " \
+    ${PYTHON_PN}-xml \
+    ${PYTHON_PN}-core \
+    ${PYTHON_PN}-numbers \
+    ${PYTHON_PN}-datetime \
+    ${PYTHON_PN}-stringold \
+"
+
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
elementpath 4.0.1 has removed 'SYMBOLS' attribute, which causing failure in ACRN 3.1.0 https://github.com/sissaschool/elementpath/commit/a76aeb88b0d103420239df1d5d001f7d7f56b5c9

misc/config_tools/scenario_config/elementpath_overlay.py", line 24, in CustomParser
|     SYMBOLS = BaseParser.SYMBOLS | {
|               ^^^^^^^^^^^^^^^^^^
| AttributeError: type object 'XPath2Parser' has no attribute 'SYMBOLS'

Issue raised: https://github.com/projectacrn/acrn-hypervisor/issues/8368

Carry python3-elementpath 3.0.2 version locally, until it gets fixed upstream

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>