### PR TITLE
linux-intel/5.15: carry patch locally

### DIFF
--- a/recipes-kernel/linux/files/0001-menuconfig-mconf-cfg-Allow-specification-of-ncurses-.patch
+++ b/recipes-kernel/linux/files/0001-menuconfig-mconf-cfg-Allow-specification-of-ncurses-.patch
@@ -1,0 +1,48 @@
+From bebd63730a433ba62549a80114a9851328aa8897 Mon Sep 17 00:00:00 2001
+From: Bruce Ashfield <bruce.ashfield@windriver.com>
+Date: Mon, 2 Jul 2018 23:10:28 -0400
+Subject: [PATCH] menuconfig,mconf-cfg: Allow specification of ncurses location
+
+In some cross build environments such as the Yocto Project build
+environment it provides an ncurses library that is compiled
+differently than the host's version.  This causes display corruption
+problems when the host's curses includes are used instead of the
+includes from the provided compiler are overridden.  There is a second
+case where there is no curses libraries at all on the host system and
+menuconfig will just fail entirely.
+
+The solution is simply to allow an override variable in
+check-lxdialog.sh for environments such as the Yocto Project.  Adding
+a CROSS_CURSES_LIB and CROSS_CURSES_INC solves the issue and allowing
+compiling and linking against the right headers and libraries.
+
+Signed-off-by: Jason Wessel <jason.wessel@windriver.com>
+cc: Michal Marek <mmarek@suse.cz>
+cc: linux-kbuild@vger.kernel.org
+Signed-off-by: Bruce Ashfield <bruce.ashfield@windriver.com>
+---
+ scripts/kconfig/mconf-cfg.sh | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/scripts/kconfig/mconf-cfg.sh b/scripts/kconfig/mconf-cfg.sh
+index c812872d7f9d..42d20819025c 100755
+--- a/scripts/kconfig/mconf-cfg.sh
++++ b/scripts/kconfig/mconf-cfg.sh
+@@ -4,6 +4,14 @@
+ PKG="ncursesw"
+ PKG2="ncurses"
+ 
++if [ "$CROSS_CURSES_LIB" != "" ]; then
++       echo libs=\'$CROSS_CURSES_LIB\'
++       if [ x"$CROSS_CURSES_INC" != x ]; then
++               echo cflags=\'$CROSS_CURSES_INC\'
++       fi
++       exit 0
++fi
++
+ if [ -n "$(command -v pkg-config)" ]; then
+ 	if pkg-config --exists $PKG; then
+ 		echo cflags=\"$(pkg-config --cflags $PKG)\"
+-- 
+2.17.1
+


### PR DESCRIPTION
Recently meta-intel removed this patch along with 5.15 kernel support.

https://git.yoctoproject.org/meta-intel/commit/?id=03229249889f621577b211de2d5c4d12914c341b