### PR TITLE
container-package: fix guest vm image path

### DIFF
--- a/classes/container-package.bbclass
+++ b/classes/container-package.bbclass
@@ -22,5 +22,5 @@ do_install[mcdepends] += "multiconfig:${ACRN_CURRENT_MC}:${CONTAINER_PACKAGE_MC}
 
 do_install () {
 	install -d ${D}${containerdir}
-	install ${CONTAINER_PACKAGE_DEPLOY_DIR}/${IMAGE_NAME}-${MACHINE}.wic ${D}${containerdir}/${IMAGE_NAME}.wic
+	install ${CONTAINER_PACKAGE_DEPLOY_DIR}/${IMAGE_NAME}-${MACHINE}.rootfs.wic ${D}${containerdir}/${IMAGE_NAME}.wic
 }


### PR DESCRIPTION
Due to recent commit:
https://git.yoctoproject.org/poky/commit/?id=6f6c79029bc2020907295858449c725952d560a1

Error:
install: cannot stat '/build/master-acrn-uos/deploy/images/intel-corei7-64/core-image-base-intel-corei7-64.wic': No such file or directory

Add 'rootfs' suffix