### PR TITLE
linux-intel-acrn/5.19: update kernel recipe

### DIFF
--- a/recipes-kernel/linux/linux-intel-acrn-rtvm_5.19.bb
+++ b/recipes-kernel/linux/linux-intel-acrn-rtvm_5.19.bb
@@ -18,7 +18,7 @@ SRC_URI:append = "  file://user-rtvm_5.15.scc \
 KMETA_BRANCH = "yocto-5.19"
 
 LINUX_VERSION ?= "5.19.0"
-SRCREV_machine ?= "3abe09b48ca3c13b50c78d3b7b0d7ce668211a70"
+SRCREV_machine ?= "200a2dbc2fdf6100f19a59c2d92174d604cf0812"
 SRCREV_meta ?= "f5d4c109d6de04005def04c3a06f053ae0c397ad"
 
 LINUX_VERSION_EXTENSION = "-mainline-tracking-acrn-preempt-rtvm"

--- a/recipes-kernel/linux/linux-intel-acrn_5.19.inc
+++ b/recipes-kernel/linux/linux-intel-acrn_5.19.inc
@@ -8,5 +8,5 @@ SRC_URI:prepend = "git://github.com/intel/mainline-tracking.git;protocol=https;n
 KMETA_BRANCH = "yocto-5.19"
 
 LINUX_VERSION ?= "5.19.0"
-SRCREV_machine ?= "a436283ed605fe33d4a6ba58470af8e01dd8b0d0"
+SRCREV_machine ?= "e999ad3f8ef0a7bcc2ce051cd28085280ce9a9c0"
 SRCREV_meta ?= "f5d4c109d6de04005def04c3a06f053ae0c397ad"


### PR DESCRIPTION
Tags:
mainline-tracking-v5.19-linux-230814T122132Z
mainline-tracking-v5.19-rt10-preempt-rt-230815T033653Z