### PR TITLE
linux-intel-acrn/5.15: update to v5.15.129

### DIFF
--- a/recipes-kernel/linux/linux-intel-acrn-rtvm_5.15.bb
+++ b/recipes-kernel/linux/linux-intel-acrn-rtvm_5.15.bb
@@ -18,9 +18,9 @@ SRC_URI:append = "  file://user-rtvm_5.15.scc \
 KBRANCH = "5.15/preempt-rt"
 KMETA_BRANCH = "yocto-5.15"
 
-LINUX_VERSION ?= "5.15.113"
-SRCREV_machine ?= "aba6427c7d2c49b8dcfad7d7ec57d0bba719bfb9"
-SRCREV_meta ?= "957ddf5f9d4bf5791e88a46ce9ec4352a6d0a171"
+LINUX_VERSION ?= "5.15.129"
+SRCREV_machine ?= "0aa56022fb159e8e577f34e6ef509e1cee4632f4"
+SRCREV_meta ?= "c16749e4e0a2f8a903c36d44f7125dd423600c57"
 
 LINUX_VERSION_EXTENSION = "-linux-intel-acrn-preempt-rtvm"
 

--- a/recipes-kernel/linux/linux-intel-acrn_5.15.inc
+++ b/recipes-kernel/linux/linux-intel-acrn_5.15.inc
@@ -8,6 +8,6 @@ SRC_URI:prepend = "git://github.com/intel/linux-intel-lts.git;protocol=https;nam
 KBRANCH = "5.15/linux"
 KMETA_BRANCH = "yocto-5.15"
 
-LINUX_VERSION ?= "5.15.113"
-SRCREV_machine ?= "97b454c47a25303d52f377e0771be19491751a00"
-SRCREV_meta ?= "957ddf5f9d4bf5791e88a46ce9ec4352a6d0a171"
+LINUX_VERSION ?= "5.15.129"
+SRCREV_machine ?= "6a3035823c5db6ee250a049f98a6d7bd53f837c7"
+SRCREV_meta ?= "c16749e4e0a2f8a903c36d44f7125dd423600c57"


### PR DESCRIPTION
Image built is verified to work as expected on ADL. But this need to build with the new xmls which is still in PR in meta-qa.

https://cbjenkins-pg.devtools.intel.com/teams-iotgdevops01/job/iotgdevops01/view/COREOS/job/GEN-LIN-COREOS.I7.64.ACRN.SATO.INTEL.RT.DEFAULT.KERNEL-BD-DLY/653/
