### PR TITLE
python3-xmlschema/3.0.1: add recipe

### DIFF
--- a/conf/distro/acrn-demo-service-vm.conf
+++ b/conf/distro/acrn-demo-service-vm.conf
@@ -18,6 +18,10 @@ PREFERRED_VERSION_linux-intel-acrn-service-vm ?= "5.15%"
 PREFERRED_VERSION_python3-elementpath = "3.0.2"
 PREFERRED_VERSION_python3-elementpath-native = "3.0.2"
 
+# Newer version throw TypeError:
+# build_schema_node_tree() got an unexpected keyword argument 'uri'
+PREFERRED_VERSION_python3-xmlschema = "3.0.1"
+PREFERRED_VERSION_python3-xmlschema-native = "3.0.1"
 
 
 # ACRN hypervisor log setting, sensible defaults

--- a/recipes-devtools/python/python3-xmlschema_3.0.1.bb
+++ b/recipes-devtools/python/python3-xmlschema_3.0.1.bb
@@ -1,0 +1,20 @@
+SUMMARY = "The xmlschema library is an implementation of XML Schema for Python (supports Python 3.6+)."
+HOMEPAGE = "https://github.com/sissaschool/xmlschema"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=26aa26eda991a3a2b61c11b62d3fda65"
+
+SRC_URI[sha256sum] = "bb24a5f4738e49d85d9eb03a2b5af26bbbbfdb055517ad953d98925094b8c026"
+
+PYPI_PACKAGE = "xmlschema"
+inherit pypi setuptools3
+
+DEPENDS += "\
+    python3-elementpath-native \
+"
+
+RDEPENDS:${PN} += "\
+    python3-elementpath \
+    python3-modules \
+"
+
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
Newer version throw errors. Carry this recipe until issue is fixed in upstream.

TypeError: build_schema_node_tree() got an unexpected keyword argument 'uri'