### PR TITLE
acrn-demo.inc: remove TCLIBCAPPEND

### DIFF
--- a/conf/distro/include/acrn-demo.inc
+++ b/conf/distro/include/acrn-demo.inc
@@ -21,8 +21,6 @@ require conf/distro/include/yocto-uninative.inc
 require conf/distro/include/security_flags.inc
 INHERIT += "uninative"
 
-TCLIBCAPPEND = ""
-
 # Set the Sato network manager to be systemd, instead of connman.
 # The Service VM needs to use networkd to get the bridges working correctly, and
 # networkd makes guest networking trivial.

--- a/recipes-core/acrn/acrn-common.inc
+++ b/recipes-core/acrn/acrn-common.inc
@@ -42,3 +42,6 @@ do_install[dirs] = "${S}"
 
 # Fixed in v1.2 and onward
 CVE_CHECK_IGNORE += "CVE-2019-18844 CVE-2021-36145"
+
+# Skip TMPDIR [buildpaths] QA check
+ERROR_QA:remove = "buildpaths"


### PR DESCRIPTION
TCLIBCAPPEND has been deprecated.

https://git.yoctoproject.org/poky/commit/?id=099c09be3c37743425486664c6457bd0301c74f0

Skip buildpaths QA checks for ACRN recipes.