### PR TITLE
setserial: fix build failure

### DIFF
--- a/recipes-bsp/setserial/setserial_%.bbappend
+++ b/recipes-bsp/setserial/setserial_%.bbappend
@@ -11,8 +11,8 @@ SYSTEMD_SERVICE:${PN} = "setserial.service"
 do_install:append() {
     install -d ${D}${sysconfdir}/
     install -d ${D}${systemd_system_unitdir}
-    install -m 0755 ${WORKDIR}/setserial ${D}${sysconfdir}/
-    install -m 0644 ${WORKDIR}/setserial.service \
+    install -m 0755 ${UNPACKDIR}/setserial ${D}${sysconfdir}/
+    install -m 0644 ${UNPACKDIR}/setserial.service \
                      ${D}${systemd_system_unitdir}/setserial.service
     sed -i \
         -e 's,@SYSCONFDIR@,${sysconfdir},g' \


### PR DESCRIPTION
install: cannot stat 'build/master-acrn-sos/work/corei7-64-oe-linux/setserial/2.17/setserial': No such file or directory